### PR TITLE
[psycholab] Fix broken example command in README

### DIFF
--- a/psycholab/README.md
+++ b/psycholab/README.md
@@ -96,7 +96,7 @@ via psycholab, as described in *Foolproof Cooperative Learning*
 
 ```
 # From google-research/
-python -m psycholab.example.prisoners_dilemma
+python -m psycholab.examples.prisoners_dilemma
 ```
 
 for the grid prisoners dilemma introduced in *A Polynomial-time Nash 


### PR DESCRIPTION
The README specifies a sample command:

```
# From google-research/
python -m psycholab.example.prisoners_dilemma
```

However, there is no `example` module but instead a `examples` module (notice the `s`). Thus, the command outputs an error:

```
/home/rlee/anaconda3/bin/python: Error while finding module specification for 'psycholab.example.prisoners_dilemma' (ModuleNotFoundError: No module named 'psycholab.example')
```


After changing it to `examples`, the script runs correctly:

```
game map:
---------
####d####
a  A B  b
#########
episode 1 returns [-3. 97.]
episode 2 returns [-1. 98.]
episode 3 returns [-2. 97.]
```