### PR TITLE
albert: ensure six >= 1.12

### DIFF
--- a/albert/requirements.txt
+++ b/albert/requirements.txt
@@ -1,3 +1,4 @@
 tensorflow >=1.11.0,<2.0.0   # CPU Version of TensorFlow.
 # tensorflow-gpu  >=1.11.0,<2.0.0  # GPU version of TensorFlow.
 sentencepiece
+six >=1.12


### PR DESCRIPTION
Hi,

this PR extents the `requirement.txt` file to use the latest version of `six`.

Latest version of `six` (>= 1.12) is needed, because the `ensure_binary` function is used in the ALBERT code. This function was introduced in six for the 1.12 release, see [changelog](https://github.com/benjaminp/six/blob/d927b9e27617abca8dbf4d66cc9265ebbde261d6/CHANGES).

Using an older version of `six` will lead to the following error message:

```bash
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/mnt/eubert/google-research/albert/create_pretraining_data.py", line 657, in <module>
    tf.app.run()
  File "/usr/local/lib/python3.6/dist-packages/tensorflow_core/python/platform/app.py", line 40, in run
    _run(main=main, argv=argv, flags_parser=_parse_flags_tolerate_undef)
  File "/usr/local/lib/python3.6/dist-packages/absl/app.py", line 299, in run
    _run_main(main, args)
  File "/usr/local/lib/python3.6/dist-packages/absl/app.py", line 250, in _run_main
    sys.exit(main(argv))
  File "/mnt/eubert/google-research/albert/create_pretraining_data.py", line 640, in main
    rng)
  File "/mnt/eubert/google-research/albert/create_pretraining_data.py", line 247, in create_training_instances
    tokens = tokenizer.tokenize(line)
  File "/mnt/eubert/google-research/albert/tokenization.py", line 254, in tokenize
    split_tokens = encode_pieces(self.sp_model, text, return_unicode=False)
  File "/mnt/eubert/google-research/albert/tokenization.py", line 121, in encode_pieces
    six.ensure_binary(piece[:-1]).replace(SPIECE_UNDERLINE, b""))
AttributeError: module 'six' has no attribute 'ensure_binary'
```