### PR TITLE
albert: ensure tf version >=1.15

### DIFF
--- a/albert/requirements.txt
+++ b/albert/requirements.txt
@@ -1,3 +1,3 @@
-tensorflow >=1.11.0,<2.0.0   # CPU Version of TensorFlow.
-# tensorflow-gpu  >=1.11.0,<2.0.0  # GPU version of TensorFlow.
+tensorflow >=1.15.0,<2.0.0   # CPU Version of TensorFlow.
+# tensorflow-gpu  >=1.15.0,<2.0.0  # GPU version of TensorFlow.
 sentencepiece


### PR DESCRIPTION
Hi,

this PR updates the minimum required version for TensorFlow to 1.15.

It fixes #91 .