### PR TITLE
"s.encode()" syntax correction to resolve PR #188

### DIFF
--- a/stochastic_to_deterministic/hashing.py
+++ b/stochastic_to_deterministic/hashing.py
@@ -52,7 +52,7 @@ def compute_hash(features, hash_matrix, hash_vector):
 
   # Concatenate features and apply MD5 hash to get a fixed length encoding.
   feature_sum_str = [''.join(x) for x in features.astype('str')]
-  feature_sum_hex = [hashlib.md5(s).hexdigest() for s in feature_sum_str]
+  feature_sum_hex = [hashlib.md5(s.encode()).hexdigest() for s in feature_sum_str]
   feature_sum_int = [int(h, 16) for h in feature_sum_hex]
 
   # Binarize features


### PR DESCRIPTION
PR #188  resolution syntax details to be added such that unicode can be encoded before md5 hashing.
@tensorflow-copybara 