### PR TITLE
Resolve warnings due to partial weights being used for model evaluation

### DIFF
--- a/kws_streaming/train/test.py
+++ b/kws_streaming/train/test.py
@@ -60,7 +60,7 @@ def tf_non_stream_model_accuracy(
   flags.batch_size = 100  # set batch size for inference
   set_size = int(set_size / flags.batch_size) * flags.batch_size
   model = models.MODELS[flags.model_name](flags)
-  model.load_weights(os.path.join(flags.train_dir, weights_name))
+  model.load_weights(os.path.join(flags.train_dir, weights_name)).expect_partial()
   total_accuracy = 0.0
   count = 0.0
   for i in range(0, set_size, flags.batch_size):
@@ -130,7 +130,7 @@ def tf_stream_state_internal_model_accuracy(
   tf.keras.backend.set_learning_phase(0)
   flags.batch_size = inference_batch_size  # set batch size
   model = models.MODELS[flags.model_name](flags)
-  model.load_weights(os.path.join(flags.train_dir, weights_name))
+  model.load_weights(os.path.join(flags.train_dir, weights_name)).expect_partial()
 
   model_stream = utils.to_streaming_inference(
       model, flags, Modes.STREAM_INTERNAL_STATE_INFERENCE)
@@ -218,7 +218,7 @@ def tf_stream_state_external_model_accuracy(
   tf.keras.backend.set_learning_phase(0)
   flags.batch_size = inference_batch_size  # set batch size
   model = models.MODELS[flags.model_name](flags)
-  model.load_weights(os.path.join(flags.train_dir, weights_name))
+  model.load_weights(os.path.join(flags.train_dir, weights_name)).expect_partial()
 
   model_stream = utils.to_streaming_inference(
       model, flags, Modes.STREAM_EXTERNAL_STATE_INFERENCE)
@@ -491,7 +491,7 @@ def convert_model_tflite(flags,
   tf.keras.backend.set_learning_phase(0)
   flags.batch_size = 1  # set batch size for inference
   model = models.MODELS[flags.model_name](flags)
-  model.load_weights(os.path.join(flags.train_dir, weights_name))
+  model.load_weights(os.path.join(flags.train_dir, weights_name)).expect_partial()
 
   # convert trained model to non streaming TFLite stateless
   # to finish other tests we do not stop program if exception happen here
@@ -524,7 +524,7 @@ def convert_model_saved(flags, folder, mode, weights_name='best_weights'):
   tf.keras.backend.set_learning_phase(0)
   flags.batch_size = 1  # set batch size for inference
   model = models.MODELS[flags.model_name](flags)
-  model.load_weights(os.path.join(flags.train_dir, weights_name))
+  model.load_weights(os.path.join(flags.train_dir, weights_name)).expect_partial()
 
   path_model = os.path.join(flags.train_dir, folder)
   if not os.path.exists(path_model):


### PR DESCRIPTION
The following warnings fill up most of the logs while evaluating a model preventing a user from analyzing it efficiently. 

The warnings that get removed with this change are as follows: (refer to the end of these logs for the ..expect_partial() suggestions provided to resolve these warnings)
WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer
W0131 13:58:46.800056 139806051583808 util.py:144] Unresolved object in checkpoint: (root).optimizer
WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer.beta_1
W0131 13:58:46.800256 139806051583808 util.py:144] Unresolved object in checkpoint: (root).optimizer.beta_1
WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer.beta_2
W0131 13:58:46.800299 139806051583808 util.py:144] Unresolved object in checkpoint: (root).optimizer.beta_2
WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer.decay
W0131 13:58:46.800335 139806051583808 util.py:144] Unresolved object in checkpoint: (root).optimizer.decay
WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer.learning_rate
W0131 13:58:46.800369 139806051583808 util.py:144] Unresolved object in checkpoint: (root).optimizer.learning_rate
WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer.iter
W0131 13:58:46.800403 139806051583808 util.py:144] Unresolved object in checkpoint: (root).optimizer.iter
WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer's state 'm' for (root).layer_with_weights-0.kernel
W0131 13:58:46.800434 139806051583808 util.py:144] Unresolved object in checkpoint: (root).optimizer's state 'm' for (root).layer_with_weights-0.kernel
WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer's state 'm' for (root).layer_with_weights-0.bias
W0131 13:58:46.800467 139806051583808 util.py:144] Unresolved object in checkpoint: (root).optimizer's state 'm' for (root).layer_with_weights-0.bias
WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer's state 'm' for (root).layer_with_weights-1.kernel
W0131 13:58:46.800501 139806051583808 util.py:144] Unresolved object in checkpoint: (root).optimizer's state 'm' for (root).layer_with_weights-1.kernel
WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer's state 'm' for (root).layer_with_weights-1.bias
W0131 13:58:46.800532 139806051583808 util.py:144] Unresolved object in checkpoint: (root).optimizer's state 'm' for (root).layer_with_weights-1.bias
WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer's state 'm' for (root).layer_with_weights-2.kernel
W0131 13:58:46.800564 139806051583808 util.py:144] Unresolved object in checkpoint: (root).optimizer's state 'm' for (root).layer_with_weights-2.kernel
WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer's state 'm' for (root).layer_with_weights-2.bias
W0131 13:58:46.800595 139806051583808 util.py:144] Unresolved object in checkpoint: (root).optimizer's state 'm' for (root).layer_with_weights-2.bias
WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer's state 'm' for (root).layer_with_weights-3.kernel
W0131 13:58:46.800626 139806051583808 util.py:144] Unresolved object in checkpoint: (root).optimizer's state 'm' for (root).layer_with_weights-3.kernel
WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer's state 'm' for (root).layer_with_weights-3.bias
W0131 13:58:46.800657 139806051583808 util.py:144] Unresolved object in checkpoint: (root).optimizer's state 'm' for (root).layer_with_weights-3.bias
WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer's state 'm' for (root).layer_with_weights-4.kernel
W0131 13:58:46.800688 139806051583808 util.py:144] Unresolved object in checkpoint: (root).optimizer's state 'm' for (root).layer_with_weights-4.kernel
WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer's state 'm' for (root).layer_with_weights-4.bias
W0131 13:58:46.800720 139806051583808 util.py:144] Unresolved object in checkpoint: (root).optimizer's state 'm' for (root).layer_with_weights-4.bias
WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer's state 'v' for (root).layer_with_weights-0.kernel
W0131 13:58:46.800751 139806051583808 util.py:144] Unresolved object in checkpoint: (root).optimizer's state 'v' for (root).layer_with_weights-0.kernel
WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer's state 'v' for (root).layer_with_weights-0.bias
W0131 13:58:46.800782 139806051583808 util.py:144] Unresolved object in checkpoint: (root).optimizer's state 'v' for (root).layer_with_weights-0.bias
WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer's state 'v' for (root).layer_with_weights-1.kernel
W0131 13:58:46.800814 139806051583808 util.py:144] Unresolved object in checkpoint: (root).optimizer's state 'v' for (root).layer_with_weights-1.kernel
WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer's state 'v' for (root).layer_with_weights-1.bias
W0131 13:58:46.800846 139806051583808 util.py:144] Unresolved object in checkpoint: (root).optimizer's state 'v' for (root).layer_with_weights-1.bias
WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer's state 'v' for (root).layer_with_weights-2.kernel
W0131 13:58:46.800878 139806051583808 util.py:144] Unresolved object in checkpoint: (root).optimizer's state 'v' for (root).layer_with_weights-2.kernel
WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer's state 'v' for (root).layer_with_weights-2.bias
W0131 13:58:46.800911 139806051583808 util.py:144] Unresolved object in checkpoint: (root).optimizer's state 'v' for (root).layer_with_weights-2.bias
WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer's state 'v' for (root).layer_with_weights-3.kernel
W0131 13:58:46.800943 139806051583808 util.py:144] Unresolved object in checkpoint: (root).optimizer's state 'v' for (root).layer_with_weights-3.kernel
WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer's state 'v' for (root).layer_with_weights-3.bias
W0131 13:58:46.800973 139806051583808 util.py:144] Unresolved object in checkpoint: (root).optimizer's state 'v' for (root).layer_with_weights-3.bias
WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer's state 'v' for (root).layer_with_weights-4.kernel
W0131 13:58:46.801004 139806051583808 util.py:144] Unresolved object in checkpoint: (root).optimizer's state 'v' for (root).layer_with_weights-4.kernel
WARNING:tensorflow:Unresolved object in checkpoint: (root).optimizer's state 'v' for (root).layer_with_weights-4.bias
W0131 13:58:46.801036 139806051583808 util.py:144] Unresolved object in checkpoint: (root).optimizer's state 'v' for (root).layer_with_weights-4.bias
WARNING:tensorflow:A checkpoint was restored (e.g. tf.train.Checkpoint.restore or tf.keras.Model.load_weights) but not all checkpointed values were used. See above for specific issues. Use expect_partial() on the load status object, e.g. tf.train.Checkpoint.restore(...).expect_partial(), to silence these warnings, or use assert_consumed() to make the check explicit. See https://www.tensorflow.org/guide/checkpoint#loading_mechanics for details.
