### PR TITLE
rl4circopt: dependency compatibility

### DIFF
--- a/rl4circopt/cirq_converter.py
+++ b/rl4circopt/cirq_converter.py
@@ -56,7 +56,7 @@ def import_from_cirq(obj):
     if not np.isclose(np.mod(obj.exponent, 2.0), 1.0):
       raise ValueError('partial ControlledZ gates are not supported')
     return circuit.ControlledZGate()
-  elif isinstance(obj, (cirq.SingleQubitMatrixGate, cirq.TwoQubitMatrixGate)):
+  elif isinstance(obj, cirq.MatrixGate):
     return circuit.MatrixGate(cirq.unitary(obj))
   elif isinstance(obj, cirq.GateOperation):
     return circuit.Operation(
@@ -106,16 +106,7 @@ def export_to_cirq(obj):
   elif isinstance(obj, circuit.ControlledZGate):
     return cirq.CZPowGate(exponent=1.0)
   elif isinstance(obj, circuit.MatrixGate):
-    num_qubits = obj.get_num_qubits()
-    operator = obj.get_operator()
-
-    if num_qubits == 1:
-      return cirq.SingleQubitMatrixGate(operator)
-    elif num_qubits == 2:
-      return cirq.TwoQubitMatrixGate(operator)
-    else:
-      raise ValueError('MatrixGate for %d qubits not supported (Cirq has'
-                       ' matrix gates only up to 2 qubits)'%num_qubits)
+    return cirq.MatrixGate(obj.get_operator())
   elif isinstance(obj, circuit.Operation):
     return cirq.GateOperation(
         export_to_cirq(obj.get_gate()),

--- a/rl4circopt/cirq_converter_test.py
+++ b/rl4circopt/cirq_converter_test.py
@@ -34,7 +34,9 @@ class TestExportAndImport(parameterized.TestCase):
       circuit.RotZGate(0.42),
       circuit.ControlledZGate(),
       circuit.MatrixGate(stats.unitary_group.rvs(2)),  # random 1-qubit unitary
-      circuit.MatrixGate(stats.unitary_group.rvs(4))   # random 2-qubit unitary
+      circuit.MatrixGate(stats.unitary_group.rvs(4)),  # random 2-qubit unitary
+      circuit.MatrixGate(stats.unitary_group.rvs(8)),  # random 3-qubit unitary
+      circuit.MatrixGate(stats.unitary_group.rvs(16))  # random 4-qubit unitary
   ])
   def test_gates(self, gate_orig):
     # export the gate to Cirq
@@ -128,15 +130,6 @@ class TestExportAndImport(parameterized.TestCase):
   def test_export_unknown_type_error(self):
     with self.assertRaisesRegex(TypeError, r'unknown type: range'):
       cirq_converter.export_to_cirq(range(42))
-
-  def test_export_large_matrix_gate_error(self):
-    matrix_gate = circuit.MatrixGate(stats.unitary_group.rvs(8))
-
-    with self.assertRaisesRegex(
-        ValueError,
-        r'MatrixGate for 3 qubits not supported \(Cirq has matrix gates only up'
-        r' to 2 qubits\)'):
-      cirq_converter.export_to_cirq(matrix_gate)
 
   def test_import_unknown_type_error(self):
     with self.assertRaisesRegex(TypeError, r'unknown type: range'):


### PR DESCRIPTION
In cirq_converter.py, changing from cirq.{Single|Two}QubitMatrixGate to
cirq.MatrixGate. This is the reaction to commit
190c41fb95a422d5828f74054b50f3ce16e20bb8 in Cirq's repository: "Extract
generic MatrixGate, deprecate SingleQubit/TwoQubitMatrixGate".