### PR TITLE
Improve Training Efficiency of TabNet

### DIFF
--- a/tabnet/data_helper_covertype.py
+++ b/tabnet/data_helper_covertype.py
@@ -123,9 +123,9 @@ def input_fn(data_file,
   if shuffle:
     dataset = dataset.shuffle(buffer_size=n_buffer)
 
+  dataset = dataset.batch(batch_size, drop_remainder=True)
   dataset = dataset.map(parse_csv, num_parallel_calls=n_parallel)
 
   # Repeat after shuffling, to prevent separate epochs from blending together.
   dataset = dataset.repeat(num_epochs)
-  dataset = dataset.batch(batch_size)
   return dataset


### PR DESCRIPTION
First of, I'd like to thank the authors for their interesting work.

**Problem**:
TabNet training is slow because the parsing of the CSV is performed on the entire file each time, instead of performed over a single batch each time (see line). This results in overhead in CPU processing, reducing the utilization of the GPU.

**Solution**:
In order to improve the training speed, we set the batching operation before the mapping operation so that the mapping operation only operates on a smaller set of data each iteration as follows:
```
    dataset = dataset.batch(batch_size, drop_remainder=True)
    dataset = dataset.map(parse_csv, num_parallel_calls=n_parallel)

    # Repeat after shuffling, to prevent separate epochs from blending together.
    dataset = dataset.repeat(num_epochs)
    return dataset
```
In terms of GPU utilization on an RTX2080Ti, I am getting about 70% utilization compared to 28% previously. More could potentially be done but this is a start.

**Caveat**:
The unfortunate side-effect of this is that the last small batch would be dropped. Fortunately this has not impacted accuracy on a test set.

Padding was tried, but I think I am not getting the shapes right, so I've used this as a solution in the interim. 

**Testing**:
Shown here are the test accuracy and test loss when tested on the CoverType dataset. When tested on the CoverType dataset, the accuracy reached on the test set is 96.23% for the final model.

![79059722-bcb89580-7cc0-11ea-9bb6-3087f2a58fdf](https://user-images.githubusercontent.com/1995167/79063178-6c066400-7ce3-11ea-9517-fc3de5bdd579.png)
![79059768-2f297580-7cc1-11ea-9027-2acf825d0eb3](https://user-images.githubusercontent.com/1995167/79063184-7c1e4380-7ce3-11ea-855f-3702e49fe234.png)
