### PR TITLE
Fixing AutoML-zero compilation warnings and errors, it builds ok now

### DIFF
--- a/automl_zero/executor.h
+++ b/automl_zero/executor.h
@@ -1108,7 +1108,7 @@ inline bool Executor<F>::TrainNoOptImpl(const IntegerT max_steps,
     // Check whether we should stop early.
     const Scalar& label = train_it->GetLabel();
     const double abs_error = ErrorComputer<F>::Compute(memory_, label);
-    if (isnan(abs_error) || abs_error > max_abs_error_) {
+    if (std::isnan(abs_error) || abs_error > max_abs_error_) {
       return false;
     }
     if (errors != nullptr) {
@@ -1186,7 +1186,7 @@ bool Executor<F>::TrainOptImpl(const IntegerT max_steps,
     // Check whether we should stop early.
     const Scalar& label = train_it->GetLabel();
     const double abs_error = ErrorComputer<F>::Compute(memory_, label);
-    if (isnan(abs_error) || abs_error > max_abs_error_) {
+    if (std::isnan(abs_error) || abs_error > max_abs_error_) {
       return false;
     }
     if (errors != nullptr) {
@@ -1289,7 +1289,7 @@ double Executor<F>::Validate(std::vector<double>* errors) {
     }
 
     const double abs_error = std::abs(error);
-    if (isnan(abs_error) || abs_error > max_abs_error_) {
+    if (std::isnan(abs_error) || abs_error > max_abs_error_) {
       // Stop early. Return infinite loss.
       return kMinFitness;
     }
@@ -1366,7 +1366,7 @@ void ExecuteAndFillLabels(const Algorithm& algorithm, Memory<F>* memory,
 constexpr double kMinusTwoOverPi = -0.63661977236758138243;
 
 inline double FlipAndSquash(const double value) {
-  if (isnan(value) || isinf(value)) {
+  if (std::isnan(value) || std::isinf(value)) {
     return 0.0;
   }
   CHECK_GE(value, 0.0);

--- a/automl_zero/regularized_evolution.cc
+++ b/automl_zero/regularized_evolution.cc
@@ -54,7 +54,7 @@ using ::std::shared_ptr;  // NOLINT
 using ::std::unique_ptr;  // NOLINT
 using ::std::vector;  // NOLINT
 
-constexpr double kLn2 = 0.69314718056;
+//constexpr double kLn2 = 0.69314718056;
 
 }  // namespace
 

--- a/automl_zero/run_demo.sh
+++ b/automl_zero/run_demo.sh
@@ -21,6 +21,7 @@ bazel run -c opt \
   --copt=-DMAX_SCALAR_ADDRESSES=4 \
   --copt=-DMAX_VECTOR_ADDRESSES=3 \
   --copt=-DMAX_MATRIX_ADDRESSES=1 \
+  --cxxopt='-std=c++14' \
   :run_search_experiment -- \
   --search_experiment_spec=" \
     search_tasks { \

--- a/automl_zero/task.h
+++ b/automl_zero/task.h
@@ -87,7 +87,7 @@ bool ItemEquals(const RankT& data1, const RankT& data2) {
 }
 template<>
 inline bool ItemEquals<Scalar>(const Scalar& data1, const Scalar& data2) {
-  return abs(data1 - data2) < kDataTolerance;
+  return std::abs(data1 - data2) < kDataTolerance;
 }
 
 template <typename RankT>


### PR DESCRIPTION
You had some std:: prefixes missing. and stdc++14 flag in bazel options - it was causing some hassle and errors in build process. 