### PR TITLE
Fix build and test problems of sketching

### DIFF
--- a/sketching/BUILD.bazel
+++ b/sketching/BUILD.bazel
@@ -27,6 +27,7 @@ cc_library(
     deps = [
         ":sketch",
         ":utils",
+        "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/random:bit_gen_ref",
         "@com_google_absl//absl/random:distributions",

--- a/sketching/benchmark_utils.cc
+++ b/sketching/benchmark_utils.cc
@@ -24,7 +24,7 @@ namespace sketch {
 
 constexpr int kAddBatchSize = 32;
 
-auto MakeAddStreams(int count) {
+std::vector<std::vector<IntFloatPair>> MakeAddStreams(int count) {
   std::vector<std::vector<IntFloatPair>> streams(kAddBatchSize);
   for (auto& stream : streams) {
     stream = CreateStream(count).first;

--- a/sketching/countmin_test.cc
+++ b/sketching/countmin_test.cc
@@ -72,8 +72,8 @@ TEST_F(CountMinTest, TestMerge) {
 
 TEST_F(CountMinTest, TestSize) {
   // Fixed cost for 5 hashes = 248 bytes. Variable cost = 5 * 5 * hash_size.
-  EXPECT_EQ(440, CountMin(5, 8).Size());
-  EXPECT_EQ(41240, CountMin(5, 2048).Size());
+  EXPECT_EQ(464, CountMin(5, 8).Size());
+  EXPECT_EQ(41264, CountMin(5, 2048).Size());
 }
 
 class CountMinCUTest : public ::testing::Test {

--- a/sketching/frequent_test.cc
+++ b/sketching/frequent_test.cc
@@ -16,7 +16,7 @@
 
 #include <memory>
 
-#include "testing/base/public/gmock.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "utils.h"
 

--- a/sketching/utils.h
+++ b/sketching/utils.h
@@ -18,7 +18,6 @@
 #include <utility>
 #include <vector>
 
-#include "base/integral_types.h"
 #include "absl/random/bit_gen_ref.h"
 #include "absl/random/random.h"
 


### PR DESCRIPTION
1. Add missing BUILD file entry.
2. Clearly define function signature of MakeAddStreams as the repository has not yet fully C++17 enabled yet.
3. Use the correct gmock includes.
4. Remove non third party include from base/.