### PR TITLE
Fix usage of dropout probability

### DIFF
--- a/demogen/models/nin.py
+++ b/demogen/models/nin.py
@@ -85,7 +85,7 @@ def _dropout_block(input_tensor, dropout_prob, spatial):
   """
   shape = input_tensor.shape
   ns = [shape[0], 1, 1, shape[3]] if spatial else None
-  out = tf.nn.dropout(input_tensor, dropout_prob, noise_shape=ns)
+  out = tf.nn.dropout(input_tensor, rate=dropout_prob, noise_shape=ns)
   return out
 
 


### PR DESCRIPTION
In my understanding, the argument `dropout_prob` is being parsed as the probability of _keeping_ rather than dropping out a parameter in `tf.nn.dropout` in the current code.  By adding the keyword `rate`, `dropout_prob` will be parsed as intended.

Am I understanding this correctly?