### PR TITLE
Student models & tests for TRILL distillation ICASSP submission

### DIFF
--- a/non_semantic_speech_benchmark/distillation/models.py
+++ b/non_semantic_speech_benchmark/distillation/models.py
@@ -17,6 +17,7 @@
 
 import tensorflow as tf
 from non_semantic_speech_benchmark.export_model import tf_frontend
+from tensorflow.python.keras.applications import mobilenet_v3 as v3_util
 
 
 @tf.function
@@ -24,35 +25,84 @@ def _sample_to_features(x):
   return tf_frontend.compute_frontend_features(x, 16000, overlap_seconds=79)
 
 
-def get_keras_model(bottleneck_dimension, output_dimension, alpha=1.0):
-  """Make a model."""
-  audio_tensor = tf.keras.Input((None,))
+def get_keras_model(bottleneck_dimension,
+                    output_dimension,
+                    alpha=1.0,
+                    mobilenet_size='small',
+                    frontend=True,
+                    avg_pool=False):
+  """Make a keras student model."""
   def _map_fn_lambda(x):
     return tf.map_fn(_sample_to_features, x, dtype=tf.float64)
-  feats = tf.keras.layers.Lambda(_map_fn_lambda)(audio_tensor)
-  feats.shape.assert_is_compatible_with([None, None, 96, 64])
-  feats = tf.transpose(feats, [0, 2, 1, 3])
-  feats = tf.reshape(feats, [-1, 96, 64, 1])
-  model = tf.keras.applications.MobileNetV3Large(
+  def _map_mobilenet_func(mnet_size):
+    mnet_size_map = {
+      "tiny": MobileNetV3Tiny,
+      "small": tf.keras.applications.MobileNetV3Small,
+      "large": tf.keras.applications.MobileNetV3Large,
+    }
+    assert mnet_size in mnet_size_map
+    return mnet_size_map[mnet_size.lower()]
+  if frontend:
+    model_in = tf.keras.Input((None,), name="audio_samples")
+    feats = tf.keras.layers.Lambda(_map_fn_lambda)(model_in)
+    feats.shape.assert_is_compatible_with([None, None, 96, 64])
+    feats = tf.transpose(feats, [0, 2, 1, 3])
+    feats = tf.reshape(feats, [-1, 96, 64, 1])
+  else:
+    model_in = tf.keras.Input((96, 64, 1), name="log_mel_spectrogram")
+    feats = model_in
+  model = _map_mobilenet_func(mobilenet_size)(
       input_shape=[96, 64, 1],
       alpha=alpha,
       minimalistic=False,
       include_top=False,
       weights=None,
-      pooling=None,
+      pooling='avg' if avg_pool is True else None,
       dropout_rate=0.0)
-  model_out = model(feats)
-  model_out.shape.assert_is_compatible_with([None, 3, 2, 1280])
-  embeddings = tf.keras.backend.batch_flatten(model_out)
-  embeddings.set_shape([None, 3 * 2 * 1280])
+  if avg_pool:
+    model_out = model(feats)
+    model_out.shape.assert_is_compatible_with([None, None])
+  else:
+    model_out = model(feats)
+    model_out.shape.assert_is_compatible_with([None, 3, 2, None])
+  if bottleneck_dimension:
+    embeddings = tf.keras.layers.Flatten()(model_out)
+    embeddings = tf.keras.layers.Dense(
+      bottleneck_dimension, activation=tf.nn.swish, name='distilled_output')(embeddings)
+  else:
+    embeddings = tf.keras.layers.Flatten(name='distilled_output')(model_out)
   # TODO(joelshor): These final layers can be large. Investigate the compression
   # techniques described in
   # https://blog.tensorflow.org/2020/02/matrix-compression-operator-tensorflow.html?m=1
-  embeddings = tf.keras.layers.Dense(
-      bottleneck_dimension, name='distilled_output')(embeddings)
-  output = tf.keras.layers.Dense(
-      output_dimension, name='embedding_to_target')(embeddings)
+  output = tf.keras.layers.Dense(output_dimension, activation=tf.nn.swish, name='embedding_to_target')(embeddings)
+  return tf.keras.Model(inputs=model_in, outputs=output)
 
-  model = tf.keras.Model(inputs=audio_tensor, outputs=output)
 
-  return model
+def MobileNetV3Tiny(input_shape=None,
+                     alpha=1.0,
+                     minimalistic=False,
+                     include_top=True,
+                     weights='imagenet',
+                     input_tensor=None,
+                     classes=1000,
+                     pooling=None,
+                     dropout_rate=0.2,
+                     classifier_activation='softmax'):
+  def stack_fn(x, kernel, activation, se_ratio):
+    def depth(d):
+      return v3_util._depth(d * alpha)
+
+    x = v3_util._inverted_res_block(x, 1, depth(16), 3, 2, se_ratio, v3_util.relu, 0)
+    x = v3_util._inverted_res_block(x, 72. / 16, depth(24), 3, 2, None, v3_util.relu, 1)
+    x = v3_util._inverted_res_block(x, 88. / 24, depth(24), 3, 1, None, v3_util.relu, 2)
+    x = v3_util._inverted_res_block(x, 4, depth(40), kernel, 2, se_ratio, activation, 3)
+    x = v3_util._inverted_res_block(x, 6, depth(40), kernel, 1, se_ratio, activation, 4)
+    x = v3_util._inverted_res_block(x, 6, depth(40), kernel, 1, se_ratio, activation, 5)
+    x = v3_util._inverted_res_block(x, 3, depth(48), kernel, 1, se_ratio, activation, 6)
+    x = v3_util._inverted_res_block(x, 6, depth(96), kernel, 2, se_ratio, activation, 8)
+    x = v3_util._inverted_res_block(x, 6, depth(96), kernel, 1, se_ratio, activation, 9)
+    return x
+
+  return v3_util.MobileNetV3(stack_fn, 512, input_shape, alpha, 'tiny', minimalistic,
+                     include_top, weights, input_tensor, classes, pooling,
+                     dropout_rate, classifier_activation)

--- a/non_semantic_speech_benchmark/distillation/models.py
+++ b/non_semantic_speech_benchmark/distillation/models.py
@@ -59,22 +59,21 @@ def get_keras_model(bottleneck_dimension,
       weights=None,
       pooling='avg' if avg_pool is True else None,
       dropout_rate=0.0)
+  model_out = model(feats)
   if avg_pool:
-    model_out = model(feats)
     model_out.shape.assert_is_compatible_with([None, None])
   else:
-    model_out = model(feats)
     model_out.shape.assert_is_compatible_with([None, 3, 2, None])
   if bottleneck_dimension:
     embeddings = tf.keras.layers.Flatten()(model_out)
     embeddings = tf.keras.layers.Dense(
-      bottleneck_dimension, activation=tf.nn.swish, name='distilled_output')(embeddings)
+      bottleneck_dimension, name='distilled_output')(embeddings)
   else:
     embeddings = tf.keras.layers.Flatten(name='distilled_output')(model_out)
   # TODO(joelshor): These final layers can be large. Investigate the compression
   # techniques described in
   # https://blog.tensorflow.org/2020/02/matrix-compression-operator-tensorflow.html?m=1
-  output = tf.keras.layers.Dense(output_dimension, activation=tf.nn.swish, name='embedding_to_target')(embeddings)
+  output = tf.keras.layers.Dense(output_dimension, name='embedding_to_target')(embeddings)
   return tf.keras.Model(inputs=model_in, outputs=output)
 
 

--- a/non_semantic_speech_benchmark/distillation/models_test.py
+++ b/non_semantic_speech_benchmark/distillation/models_test.py
@@ -24,12 +24,41 @@ from non_semantic_speech_benchmark.distillation import models
 
 class ModelsTest(absltest.TestCase):
 
-  def test_model(self):
-    input_tensor = tf.zeros([2, 32000], dtype=tf.float32)
+  def test_model_frontend(self):
+    input_tensor = tf.zeros([2, 32000], dtype=tf.float32)  # audio signal
     m = models.get_keras_model(3, 5)
     o = m(input_tensor)
     o.shape.assert_has_rank(2)
     self.assertEqual(o.shape[1], 5)
+
+  def test_model_no_frontend(self):
+    input_tensor = tf.zeros([1, 96, 64, 1], dtype=tf.float32)  # log Mel spectrogram
+    m = models.get_keras_model(3, 5, frontend=False)
+    o = m(input_tensor)
+    o.shape.assert_has_rank(2)
+    self.assertEqual(o.shape[1], 5)
+
+  def test_model_no_bottleneck(self):
+    input_tensor = tf.zeros([2, 32000], dtype=tf.float32)
+    m = models.get_keras_model(0, 5)
+    o = m(input_tensor)
+    o.shape.assert_has_rank(2)
+    self.assertEqual(o.shape[1], 5)
+
+  def test_invalid_mobilenet_size(self):
+    invalid_mobilenet_size = "huuuge"
+    with self.assertRaises(AssertionError) as exception_context:
+      models.get_keras_model(3, 5, mobilenet_size=invalid_mobilenet_size)
+    if not isinstance(exception_context.exception, AssertionError):
+      self.fail()
+
+  def test_valid_mobilenet_size(self):
+    input_tensor = tf.zeros([2, 32000], dtype=tf.float32)
+    for mobilenet_size in ("tiny", "small", "large"):
+      m = models.get_keras_model(3, 5, mobilenet_size=mobilenet_size)
+      o = m(input_tensor)
+      o.shape.assert_has_rank(2)
+      self.assertEqual(o.shape[1], 5)
 
 
 if __name__ == '__main__':

--- a/non_semantic_speech_benchmark/distillation/train_keras.py
+++ b/non_semantic_speech_benchmark/distillation/train_keras.py
@@ -72,6 +72,9 @@ flags.DEFINE_integer('training_steps', 1000,
 flags.DEFINE_integer('measurement_store_interval', 10,
                      'The number of steps between storing objective value in '
                      'measurements.')
+flags.DEFINE_integer('checkpoint_max_to_keep', None,
+                     'Number of previous checkpoints to save to disk.'
+                     'Default (None) is to store all checkpoints.')
 flags.DEFINE_integer('num_epochs', 50, 'Number of epochs to train for.')
 flags.DEFINE_alias('e' ,'num_epochs')
 
@@ -132,7 +135,7 @@ def train_and_report(debug=False):
   global_step = opt.iterations
   checkpoint = tf.train.Checkpoint(model=model, global_step=global_step)
   manager = tf.train.CheckpointManager(
-      checkpoint, FLAGS.logdir, max_to_keep=None)
+      checkpoint, FLAGS.logdir, max_to_keep=FLAGS.checkpoint_max_to_keep)
   logging.info('Checkpoint prefix: %s', FLAGS.logdir)
   checkpoint.restore(manager.latest_checkpoint)
 

--- a/non_semantic_speech_benchmark/distillation/train_keras.py
+++ b/non_semantic_speech_benchmark/distillation/train_keras.py
@@ -18,6 +18,7 @@
 
 from absl import app
 from absl import flags
+from absl import logging
 
 import tensorflow.compat.v2 as tf
 import tensorflow_hub as hub  # pylint:disable=g-bad-import-order
@@ -27,64 +28,97 @@ from non_semantic_speech_benchmark.distillation import models
 
 FLAGS = flags.FLAGS
 
+# Data config flags.
 flags.DEFINE_string('file_pattern', None, 'Dataset location.')
-flags.DEFINE_string('samples_key', None, 'Samples name.')
-flags.DEFINE_integer('ml', 16000, 'Minimum length.')
-flags.DEFINE_alias('min_length', 'ml')
+flags.DEFINE_integer('output_dimension', None, 'Dimension of targets.')
 
-# Teacher / student network flags.
+flags.DEFINE_boolean('precomputed_frontend_and_targets', False,
+                     'Flag to enable training with precomputed frontend and targets. '
+                     'If True, `file_pattern` must point to tf_records of tf.Examples. '
+                     'See get_data.get_precomputed_data for details about tf.Example formatting. '
+                     'If True, `teacher_model_hub`, `output_key`, `samples_key` '
+                     'and `min_length` flags are ignored.')
+flags.DEFINE_string('frontend_key', None, 'Frontend feature key in precomputed tf.Examples. '
+                    'This flag is ignored if `precomputed_frontend_and_targets` is False.')
+flags.DEFINE_string('target_key', None, 'Teacher embedding key in precomputed tf.Examples. '
+                    'This flag is ignored if `precomputed_frontend_and_targets` is False.')
+
 flags.DEFINE_string('teacher_model_hub', None, 'Hub teacher model.')
 flags.DEFINE_string('output_key', None, 'Teacher model output_key.')
-flags.DEFINE_integer('output_dimension', None, 'Dimension of targets.')
-flags.DEFINE_integer('bd', None, 'Dimension of bottleneck.')
-flags.DEFINE_alias('bottleneck_dimension', 'bd')
-flags.DEFINE_float('al', 1.0, 'Alpha controlling model size.')
-flags.DEFINE_alias('alpha', 'al')
+flags.DEFINE_string('samples_key', None, 'Samples name.')
+flags.DEFINE_integer('min_length', 16000, 'Minimum audio sample length.')
+flags.DEFINE_alias('ml', 'min_length')
 
-flags.DEFINE_integer('tbs', 1, 'Hyperparameter: batch size.')
-flags.DEFINE_alias('train_batch_size', 'tbs')
+# Student network config flags.
+flags.DEFINE_integer('bottleneck_dimension', None, 'Dimension of bottleneck. '
+                     'If 0, bottleneck layer is excluded.')
+flags.DEFINE_float('alpha', 1.0, 'Alpha controlling MobileNet width.')
+flags.DEFINE_boolean('average_pool', False, 'Average pool MobileNet output.')
+flags.DEFINE_string('mobilenet_size', 'small', 'Size specification for MobileNet in student model. '
+                    'valid entries are `tiny`, `small`, and `large`.')
+flags.DEFINE_alias('bd', 'bottleneck_dimension')
+flags.DEFINE_alias('al', 'alpha')
+flags.DEFINE_alias('ap', 'average_pool')
+flags.DEFINE_alias('mnet', 'mobilenet_size')
+
+# Training config flags.
+flags.DEFINE_integer('train_batch_size', 1, 'Hyperparameter: batch size.')
+flags.DEFINE_alias('tbs', 'train_batch_size')
 flags.DEFINE_integer('shuffle_buffer_size', None, 'shuffle_buffer_size')
-
 flags.DEFINE_float('lr', 0.001, 'Hyperparameter: learning rate.')
-
-flags.DEFINE_string('logdir', None,
-                    'Path to directory where to store summaries.')
-
+flags.DEFINE_string('logdir', None, 'Path to directory where to store summaries.')
 flags.DEFINE_integer('training_steps', 1000,
                      'The number of steps to run training for.')
 flags.DEFINE_integer('measurement_store_interval', 10,
                      'The number of steps between storing objective value in '
                      'measurements.')
+flags.DEFINE_integer('num_epochs', 50, 'Number of epochs to train for.')
+flags.DEFINE_alias('e' ,'num_epochs')
+
 
 
 def train_and_report(debug=False):
   """Trains the classifier."""
-  tf.logging.info('samples_key: %s', FLAGS.samples_key)
-  tf.logging.info('Logdir: %s', FLAGS.logdir)
-  tf.logging.info('Batch size: %s', FLAGS.train_batch_size)
+  logging.info('Logdir: %s', FLAGS.logdir)
+  logging.info('Batch size: %s', FLAGS.train_batch_size)
 
-  reader = tf.data.TFRecordDataset
-  ds = get_data.get_data(
+  if FLAGS.precomputed_frontend_and_targets:
+    ds = get_data.get_precomputed_data(
       file_pattern=FLAGS.file_pattern,
-      teacher_fn=get_data.savedmodel_to_func(
-          hub.load(FLAGS.teacher_model_hub), FLAGS.output_key),
       output_dimension=FLAGS.output_dimension,
-      reader=reader,
+      frontend_key=FLAGS.frontend_key,
+      target_key=FLAGS.target_key,
+      batch_size=FLAGS.train_batch_size,
+      num_epochs=FLAGS.num_epochs,
+      shuffle_buffer_size=FLAGS.shuffle_buffer_size)
+    ds.element_spec[0].shape.assert_has_rank(3)  # log Mel spectrograms
+    ds.element_spec[1].shape.assert_has_rank(2)  # teacher embeddings
+  else:
+    ds = get_data.get_data(
+      file_pattern=FLAGS.file_pattern,
+      teacher_fn=get_data.savedmodel_to_func(hub.load(FLAGS.teacher_model_hub), FLAGS.output_key),
+      output_dimension=FLAGS.output_dimension,
+      reader=tf.data.TFRecordDataset,
       samples_key=FLAGS.samples_key,
       min_length=FLAGS.min_length,
       batch_size=FLAGS.train_batch_size,
       loop_forever=True,
       shuffle=True,
       shuffle_buffer_size=FLAGS.shuffle_buffer_size)
-  assert len(ds.element_spec) == 2, ds.element_spec
-  ds.element_spec[0].shape.assert_has_rank(2)  # audio samples
-  ds.element_spec[1].shape.assert_has_rank(2)  # teacher embeddings
+    assert len(ds.element_spec) == 2, ds.element_spec
+    ds.element_spec[0].shape.assert_has_rank(2)  # audio samples
+    ds.element_spec[1].shape.assert_has_rank(2)  # teacher embeddings
   output_dimension = ds.element_spec[1].shape[1]
   assert output_dimension == FLAGS.output_dimension
 
   # Create model, loss, and other objects.
   model = models.get_keras_model(
-      FLAGS.bottleneck_dimension, output_dimension, alpha=FLAGS.alpha)
+    bottleneck_dimension=FLAGS.bottleneck_dimension,
+    output_dimension=output_dimension,
+    alpha=FLAGS.alpha,
+    mobilenet_size=FLAGS.mobilenet_size,
+    frontend=not FLAGS.precomputed_frontend_and_targets,
+    avg_pool=FLAGS.average_pool)
   # Define loss and optimizer hyparameters.
   loss_obj = tf.keras.losses.MeanSquaredError(name='mse_loss')
   opt = tf.keras.optimizers.Adam(
@@ -99,33 +133,35 @@ def train_and_report(debug=False):
   checkpoint = tf.train.Checkpoint(model=model, global_step=global_step)
   manager = tf.train.CheckpointManager(
       checkpoint, FLAGS.logdir, max_to_keep=None)
-  tf.logging.info('Checkpoint prefix: %s', FLAGS.logdir)
+  logging.info('Checkpoint prefix: %s', FLAGS.logdir)
   checkpoint.restore(manager.latest_checkpoint)
 
   if debug: return
-  for wav_samples, targets in ds:
-    wav_samples.shape.assert_has_rank(2)
-    wav_samples.shape.assert_is_compatible_with(
+  for inputs, targets in ds:
+    if FLAGS.precomputed_frontend_and_targets:  # inputs are spectrograms
+      inputs.shape.assert_has_rank(3)
+      inputs.shape.assert_is_compatible_with(
+        [FLAGS.train_batch_size, 96, 64])
+    else:  # inputs are audio vectors
+      inputs.shape.assert_has_rank(2)
+      inputs.shape.assert_is_compatible_with(
         [FLAGS.train_batch_size, FLAGS.min_length])
     targets.shape.assert_has_rank(2)
     targets.shape.assert_is_compatible_with(
         [FLAGS.train_batch_size, FLAGS.output_dimension])
-
-    train_step(wav_samples, targets, global_step)
-
+    train_step(inputs, targets, global_step)
     # Optional print output and save model.
     if global_step % 10 == 0:
-      tf.logging.info('step: %i, train loss: %f, train mean abs error: %f',
+      logging.info('step: %i, train loss: %f, train mean abs error: %f',
                       global_step, train_loss.result(), train_mae.result())
     if global_step % FLAGS.measurement_store_interval == 0:
       manager.save(checkpoint_number=global_step)
 
   manager.save(checkpoint_number=global_step)
-  tf.logging.info('Finished training.')
+  logging.info('Finished training.')
 
 
-def get_train_step(model, loss_obj, opt, train_loss, train_mae,
-                   summary_writer):
+def get_train_step(model, loss_obj, opt, train_loss, train_mae, summary_writer):
   """Returns a function for train step."""
   @tf.function
   def train_step(wav_samples, targets, step):
@@ -153,13 +189,18 @@ def get_train_step(model, loss_obj, opt, train_loss, train_mae,
 
 def main(unused_argv):
   assert FLAGS.file_pattern
-  assert FLAGS.teacher_model_hub
   assert FLAGS.output_dimension
-  assert FLAGS.output_key
-  assert FLAGS.bottleneck_dimension
+  assert FLAGS.bottleneck_dimension >= 0
   assert FLAGS.shuffle_buffer_size
-  assert FLAGS.samples_key
   assert FLAGS.logdir
+
+  if FLAGS.precomputed_frontend_and_targets:
+    assert FLAGS.frontend_key
+    assert FLAGS.target_key
+  else:
+    assert FLAGS.teacher_model_hub
+    assert FLAGS.output_key
+    assert FLAGS.samples_key
 
   tf.enable_v2_behavior()
   assert tf.executing_eagerly()


### PR DESCRIPTION
- Added "MobileNetV3Tiny" Implementation
- Added option to create student model without frontend (In support of distilling on pre-computed spectrograms and targets).
- Added option to average-pool MobileNet output.
- Added option to exclude bottleneck layer.
- Unit tests for above functionality.