### PR TITLE
Update Frechet Audio Distance to be compatible with Python 3. Various bug and typo fixes.

### DIFF
--- a/frechet_audio_distance/.gitignore
+++ b/frechet_audio_distance/.gitignore
@@ -1,0 +1,7 @@
+data
+stats
+tensorflow_models
+test_audio
+
+# intellij idea
+.idea

--- a/frechet_audio_distance/README.md
+++ b/frechet_audio_distance/README.md
@@ -14,12 +14,16 @@ FAD depends on:
 *   [`numpy`](http://www.numpy.org/)
 *   [`scipy`](http://www.scipy.org/)
 *   [`tensorflow`](http://www.tensorflow.org/)
-*   [`Pyton Beam`](https://beam.apache.org/documentation/sdks/python/)
+*   [`Python Beam`](https://beam.apache.org/documentation/sdks/python/)
 *   [`Audioset model Vggish`](https://github.com/tensorflow/models/tree/master/research/audioset)
 
 and also requires downloading a VGG model checkpoint file:
 
 *   [VGGish model checkpoint](https://storage.googleapis.com/audioset/vggish_model.ckpt)
+
+### Python 3 and Apache Beam
+Apache Beam >= 2.14.0 has been updated to work with Python versions 3.5, 3.6, and 3.7.
+Read more about on-going Python 3 support [here](https://beam.apache.org/roadmap/python-sdk/#python-3-support)
 
 ### Example installation and use
 
@@ -36,8 +40,8 @@ Create a virtualenv to isolate from everything else and activate it first.
 ```shell
 # Python 2
 $ virtualenv fad
-# or Oython 3
-$ python3 -m venv fad # (apache-beam does not yet support Python 3)
+# or Python 3
+$ python3 -m venv fad
 # activate the virtualenv
 $ source fad/bin/activate
 # Upgrade pip
@@ -65,7 +69,7 @@ This will generate a set of background test files (sine waves at different frequ
 And two test sets of sine waves with distortions.
 
 ```shell
-$ python -m frechet_audio_distance.gen_test_files --test_files "test_audio"
+$ python -m gen_test_files --test_files "test_audio"
 
 #Add them to file lists:
 $ ls --color=never test_audio/background/*  > test_audio/test_files_background.cvs
@@ -76,13 +80,13 @@ $ ls --color=never test_audio/test2/*  > test_audio/test_files_test2.cvs
 #### Compute embeddings and eastimate multivariate Gaussians
 ```shell
 $ mkdir -p stats
-$ python -m frechet_audio_distance.create_embeddings_main --input_files test_audio/test_files_background.cvs --stats stats/background_stats
-$ python -m frechet_audio_distance.create_embeddings_main --input_files test_audio/test_files_test1.cvs --stats stats/test1_stats
-$ python -m frechet_audio_distance.create_embeddings_main --input_files test_audio/test_files_test2.cvs --stats stats/test2_stats
+$ python -m create_embeddings_main --input_files test_audio/test_files_background.cvs --stats stats/background_stats
+$ python -m create_embeddings_main --input_files test_audio/test_files_test1.cvs --stats stats/test1_stats
+$ python -m create_embeddings_main --input_files test_audio/test_files_test2.cvs --stats stats/test2_stats
 ```
 
 #### Compute the FAD from the stats
 ```shell
-$ python -m frechet_audio_distance.compute_fad --background_stats stats/background_stats --test_stats stats/test1_stats
-$ python -m frechet_audio_distance.compute_fad --background_stats stats/background_stats --test_stats stats/test2_stats
+$ python -m compute_fad --background_stats stats/background_stats --test_stats stats/test1_stats
+$ python -m compute_fad --background_stats stats/background_stats --test_stats stats/test2_stats
 ```

--- a/frechet_audio_distance/audioset_model.py
+++ b/frechet_audio_distance/audioset_model.py
@@ -22,9 +22,9 @@ from __future__ import print_function
 import numpy as np
 import tensorflow.compat.v1 as tf  # tf
 
-from tensorflow_models.audioset import mel_features
-from tensorflow_models.audioset import vggish_params
-from tensorflow_models.audioset import vggish_slim
+from tensorflow_models.audioset.vggish import mel_features
+from tensorflow_models.audioset.vggish import vggish_params
+from tensorflow_models.audioset.vggish import vggish_slim
 
 
 class AudioSetModel(object):
@@ -87,7 +87,7 @@ class AudioSetModel(object):
       np_samples /= np.maximum(min_ratio, np.amax(np_samples))
     if self._step_size is not None:
       samples_splits = []
-      for i in xrange(0, samples - vggish_params.SAMPLE_RATE + 1,
+      for i in range(0, samples - vggish_params.SAMPLE_RATE + 1,
                       self._step_size):
         samples_splits.append(np_samples[i:i + vggish_params.SAMPLE_RATE])
     else:

--- a/frechet_audio_distance/compute_fad.py
+++ b/frechet_audio_distance/compute_fad.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 from absl import app
 from absl import flags
 
-from frechet_audio_distance import fad_utils
+import fad_utils
 
 flags.DEFINE_string("background_stats", None,
                     "Tf record containing the background stats (mu sigma).")

--- a/frechet_audio_distance/create_embeddings_beam.py
+++ b/frechet_audio_distance/create_embeddings_beam.py
@@ -33,7 +33,7 @@ import scipy.io.wavfile
 import scipy.spatial.distance
 import tensorflow.compat.v1 as tf
 
-from frechet_audio_distance.audioset_model import AudioSetModel
+from audioset_model import AudioSetModel
 
 
 def _int64_feature(value):

--- a/frechet_audio_distance/create_embeddings_main.py
+++ b/frechet_audio_distance/create_embeddings_main.py
@@ -23,7 +23,7 @@ import collections
 from absl import app
 from absl import flags
 
-from frechet_audio_distance import create_embeddings_beam
+import create_embeddings_beam
 
 flags.DEFINE_string('input_files', None,
                     'File containing a list of all input audio files.')

--- a/frechet_audio_distance/fad_utils.py
+++ b/frechet_audio_distance/fad_utils.py
@@ -34,7 +34,7 @@ def read_mean_and_covariances(filename):
   Returns:
     The values of mu and sigma.
   """
-  tf_record = tf.python_io.tf_record_iterator(filename).next()
+  tf_record = next(tf.python_io.tf_record_iterator(filename))
   example = tf.train.Example().FromString(tf_record)
   mu = np.array(example.features.feature['mu'].float_list.value)
   emb_len = np.array(

--- a/frechet_audio_distance/requirements.txt
+++ b/frechet_audio_distance/requirements.txt
@@ -1,5 +1,5 @@
 absl-py>=0.7.0
-apache-beam>=2.9.0
+apache-beam>=2.14.0
 astor>=0.7.1
 avro>=1.8.2
 backports.functools-lru-cache>=1.5


### PR DESCRIPTION
- Upgraded Python Beam to 2.14.0 (supports Python 3)

- Updated imports to reflect running fad from root folder

- Updated paths to reflect new tensorflow_models structure

- Added .gitignore