### PR TITLE
Fixed Typo in Cell mixer

### DIFF
--- a/cell_mixer/README.md
+++ b/cell_mixer/README.md
@@ -9,7 +9,7 @@ packages:
 pip3 install pandas anndata absl-py
 ```
 
-You will also need to install the following R/Biocinductor packages
+You will also need to install the following R/Bioconductor packages
 
 ```R
 install.packages("devtools")


### PR DESCRIPTION
In the Cell_mixer readme, while giving instructions to install the R Bioconductor package, it was mentioned as Biocinductor.

This PR will fix this small Typo so that there will be no confusion.