### PR TITLE
GoEmotions add model export flag and functionality for bert_classifier.py

### DIFF
--- a/goemotions/bert_classifier.py
+++ b/goemotions/bert_classifier.py
@@ -58,11 +58,11 @@ flags = tf.flags
 FLAGS = flags.FLAGS
 
 ## Required parameters
-flags.DEFINE_string("emotion_file", "data/emotions.txt",
+flags.DEFINE_string("emotion_file", "goemotions/data/emotions.txt",
                     "File containing a list of emotions.")
 
 flags.DEFINE_string(
-    "data_dir", "data",
+    "data_dir", "goemotions/data",
     "The input data dir. Should contain the .tsv files (or other data files) "
     "for the task.")
 
@@ -164,7 +164,7 @@ flags.DEFINE_integer("iterations_per_loop", 1000,
 flags.DEFINE_integer("eval_steps", None,
                      "How many steps to take to go over the eval set.")
 
-flags.DEFINE_string("sentiment_file", "sentiment_dict.json",
+flags.DEFINE_string("sentiment_file", "goemotions/data/sentiment_dict.json",
                     "Dictionary of sentiment categories.")
 
 flags.DEFINE_string(

--- a/goemotions/requirements.txt
+++ b/goemotions/requirements.txt
@@ -27,5 +27,6 @@ seaborn>=0.9.0
 six>=1.12.0
 sklearn>=0.0
 statsmodels>=0.10.1
+tf-slim>=1.1.0
 toolz>=0.10.0
 zipp>=0.6.0


### PR DESCRIPTION
### Main features added:

- Added boolean flag `do_export`. Default set to `False`.
- If `do_export` flag is `True`, then the model will be exported from its latest checkpoint to `SavedModel` format.
- Changed requirement that either the `do_train` or `do_predict` flags must be `True`, now either the `do_train`, `do_predict`, or `do_export` flag must be `True`.

These features will allow the user to export their model after training to a servable format, `SavedModel`, with the change of a flag. This will help beginner TensorFlow users, like myself, utilize the model elsewhere.

A feature to consider developing is to show how to load and predict with the `SavedModel`, which I have semi-written and can contribute in another PR.

### Minor changes made:

- Added 'goemotions/' prefix to file/directory related flags
- Added 'tf-slim' to requirements file

The additions were to address some oversights based from the `bert_classifier.py`. It seems that contributors were not on the same page about where to run this script. As the README notes the command `python -m goemotions.bert_classifier`, I took the interpretation that the script should be run from the root directory. Thus, some of the flags regarding file/directory locations needed to be changed to fit this interpretation. Also, `bert_classifier.py` imports the file `bert/modeling.py`, which imports the `tf-slim` package. This was not included in the `requirements.txt` file, so I added it.

Another minor change could be made with respect to deprecated functions/classes. Although it seems inconsequential to me, it definitely bugged me to see those warning messages. This could be addressed in another PR.