### PR TITLE
Initial Bazel integration.

### DIFF
--- a/npy_array/.bazelrc
+++ b/npy_array/.bazelrc
@@ -1,0 +1,2 @@
+build --cxxopt=-std=c++17 --cxxopt=-stdlib=libc++
+test --cxxopt=-std=c++17 --cxxopt=-stdlib=libc++

--- a/npy_array/BUILD.bazel
+++ b/npy_array/BUILD.bazel
@@ -1,0 +1,21 @@
+cc_library(
+    name = "npy_array",
+    srcs = ["npy_array/npy_array.cc"],
+    hdrs = ["npy_array/npy_array.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_dsharlet_array//:array",
+        "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_test(
+    name = "npy_array_test",
+    srcs = ["tests/npy_array_test.cc"],
+    deps = [
+        ":npy_array",
+        "@com_github_dsharlet_array//:array",
+        "@gtest//:gtest_main",
+    ],
+)

--- a/npy_array/README.md
+++ b/npy_array/README.md
@@ -4,14 +4,26 @@ This is not an official Google product.
 
 ## Overview
 
-Exposes `npy_array::SerializeToString` to serialize `nda::array` (from the
-[array](https://github.com/dsharlet/array) library) instances to the numpy
-array format (https://numpy.org/devdocs/reference/generated/numpy.lib.format.html).
+This library provides two functions:
+
+* `npy_array::SerializeToString` serializes (writes) instances of `nda::array` (from the [array](https://github.com/dsharlet/array) library) to the numpy array ["npy format"](https://numpy.org/devdocs/reference/generated/numpy.lib.format.html).
+* `npy_array::DeserializeFromNpyString` deserializes (reads) data in the numpy array format into instances of `nda::array`.
 
 ## Code structure
 
-* /npy_array : C++ library
-* /tests : Tests for the C++ library
+* /npy_array: C++ library.
+* /tests: Tests for the C++ library.
+
+## Build and test
+
+### Bazel
+```
+bazel build //:npy_array
+```
+
+```
+bazel test //:npy_array_test
+```
 
 ------
 

--- a/npy_array/WORKSPACE.bazel
+++ b/npy_array/WORKSPACE.bazel
@@ -1,0 +1,45 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# https://github.com/dsharlet/array
+new_git_repository(
+    name = "com_github_dsharlet_array",
+    branch = "master",
+    build_file = "//:array.BUILD",
+    remote = "https://github.com/dsharlet/array.git",
+)
+
+# abseil-cpp, depends on rules_cc.
+http_archive(
+    name = "rules_cc",
+    strip_prefix = "rules_cc-262ebec3c2296296526740db4aefce68c80de7fa",
+    urls = ["https://github.com/bazelbuild/rules_cc/archive/262ebec3c2296296526740db4aefce68c80de7fa.zip"],
+)
+
+http_archive(
+    name = "com_google_absl",
+    strip_prefix = "abseil-cpp-98eb410c93ad059f9bba1bf43f5bb916fc92a5ea",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/98eb410c93ad059f9bba1bf43f5bb916fc92a5ea.zip"],
+)
+
+# glog, depends on gflags.
+http_archive(
+    name = "com_github_gflags_gflags",
+    sha256 = "34af2f15cf7367513b352bdcd2493ab14ce43692d2dcd9dfc499492966c64dcf",
+    strip_prefix = "gflags-2.2.2",
+    urls = ["https://github.com/gflags/gflags/archive/v2.2.2.tar.gz"],
+)
+
+http_archive(
+    name = "com_github_google_glog",
+    sha256 = "62efeb57ff70db9ea2129a16d0f908941e355d09d6d83c9f7b18557c0a7ab59e",
+    strip_prefix = "glog-d516278b1cd33cd148e8989aec488b6049a4ca0b",
+    urls = ["https://github.com/google/glog/archive/d516278b1cd33cd148e8989aec488b6049a4ca0b.zip"],
+)
+
+# gtest.
+git_repository(
+    name = "gtest",
+    branch = "v1.10.x",
+    remote = "https://github.com/google/googletest",
+)

--- a/npy_array/array.BUILD
+++ b/npy_array/array.BUILD
@@ -1,0 +1,11 @@
+cc_library(
+    name = "array",
+    hdrs = [
+        "array.h",
+        "ein_reduce.h",
+        "image.h",
+        "matrix.h",
+    ],
+    include_prefix = "third_party/array",
+    visibility = ["//visibility:public"],
+)

--- a/npy_array/npy_array/npy_array.cc
+++ b/npy_array/npy_array/npy_array.cc
@@ -111,7 +111,7 @@ std::string NpyDataTypeString<uint32_t>() {
 }
 
 template <>
-std::string NpyDataTypeString<unsigned long long_t>() {
+std::string NpyDataTypeString<uint64_t>() {
   return "u";
 }
 

--- a/npy_array/npy_array/npy_array.h
+++ b/npy_array/npy_array/npy_array.h
@@ -23,9 +23,9 @@
 #include <utility>
 #include <vector>
 
-#include "glog/logging.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
+#include "glog/logging.h"
 #include "third_party/array/array.h"
 
 namespace npy_array {


### PR DESCRIPTION
* Added WORKSPACE.bazel to pull in deps.
* Added basic BUILD.bazel.
* Added .bazelrc to use the C++17 toolchain so that it can be built
  without explicit commandline flags.

* Fixed a small bug (unsigned long long_t --> uint64_t).

Working:
```
bazel build //:npy_array
bazel test //:npy_array_test
```