### PR TITLE
chosen_flags._asdict().items()

### DIFF
--- a/performer/models/slim_performer/pytorch/train.py
+++ b/performer/models/slim_performer/pytorch/train.py
@@ -195,7 +195,7 @@ def set_default_flags(arg_code):
 
   chosen_flags = possible_flags[arg_code]
 
-  for flag_name, flag_value in chosen_flags._asdict().iteritems():
+  for flag_name, flag_value in chosen_flags._asdict().items():
     setattr(FLAGS, flag_name, flag_value)
 
 


### PR DESCRIPTION
Line 198 was chosen_flags._asdict().iteritems() doesn't work in python 3.x so replaced with .items()