### PR TITLE
Stop SlotAttention training when global_step == num_train_steps.

### DIFF
--- a/slot_attention/object_discovery/train.py
+++ b/slot_attention/object_discovery/train.py
@@ -101,7 +101,7 @@ def main(argv):
     logging.info("Initializing from scratch.")
 
   start = time.time()
-  for _ in range(num_train_steps):
+  while global_step < num_train_steps:
     batch = next(data_iterator)
 
     # Learning rate warm-up.


### PR DESCRIPTION
The training loop should terminate when global_step == num_train_steps. Otherwise, resuming training from an intermediate checkpoint will train for longer than specified by num_train_steps.