### PR TITLE
Fix auto reset attribute name for Social_rl

### DIFF
--- a/social_rl/adversarial_env/adversarial_env.py
+++ b/social_rl/adversarial_env/adversarial_env.py
@@ -182,7 +182,7 @@ class AdversarialGymWrapper(gym_wrapper.GymWrapper):
 
   def _step(self, action):
     # Automatically reset the environments on step if they need to be reset.
-    if self._handle_auto_reset and self._done:
+    if self._auto_reset and self._done:
       return self.reset_agent()
 
     action = action.item() if self._action_is_discrete else action


### PR DESCRIPTION
_handle_auto_reset does not exist, this is a revert to the old attribute name.

`AttributeError: 'AdversarialEnv' object has no attribute '_handle_auto_reset'`