### PR TITLE
Fix final document dense layer scope for SMITH

### DIFF
--- a/smith/layers.py
+++ b/smith/layers.py
@@ -347,7 +347,7 @@ def get_seq_rep_from_bert(bert_model):
   siamese_input_tensor = bert_model.get_pooled_output()
   hidden_size = siamese_input_tensor.shape[-1].value
   siamese_input_tensor = tf.layers.dense(
-      siamese_input_tensor, units=hidden_size, activation=tf.nn.relu)
+      siamese_input_tensor, units=hidden_size, activation=tf.nn.relu, name='dense')
   normalized_siamese_input_tensor = tf.nn.l2_normalize(
       siamese_input_tensor, axis=1)
   return normalized_siamese_input_tensor


### PR DESCRIPTION
Fixed new variables being created for the final dense layer (pre l2-norm layer), as opposed to reusing weights corresponding to the siamese architecture mentioned in [SMITH (Siamese Multi-depth Transformer-based Hierarchical Encoder) model](https://research.google/pubs/pub49617/).

Verified additional variables being created in the checkpoints mentioned in the repo.
dense_1 is created incorrectly for the siamese architecture  


```
 ('seq_rep_from_bert_doc_dense/dense/bias', [256]),
 ('seq_rep_from_bert_doc_dense/dense/kernel', [256, 256]),
 ('seq_rep_from_bert_doc_dense/dense_1/bias', [256]),
 ('seq_rep_from_bert_doc_dense/dense_1/kernel', [256, 256])

```
Dense layer named as `dense (seq_rep_from_bert_doc_dense/dense/..)` for reusing trained weights.