### PR TITLE
Rectified typo error in .sh files

### DIFF
--- a/hitnet/evaluate_flyingthings.sh
+++ b/hitnet/evaluate_flyingthings.sh
@@ -38,7 +38,7 @@ pip3 install -r requirements.txt
 mkdir -p $MODEL_PATH
 wget -P $MODEL_PATH -N https://storage.googleapis.com/tensorflow-graphics/models/hitnet/default_models/$MODEL_NAME
 
-python -m predict.py \
+python -m predict \
   --data_pattern=$DATASETS_LOCATION \
   --model_path=$MODEL_PATH/$MODEL_NAME \
   --png_disparity_factor=128 \

--- a/hitnet/predict_eth.sh
+++ b/hitnet/predict_eth.sh
@@ -35,7 +35,7 @@ pip3 install -r requirements.txt
 mkdir -p $MODEL_PATH
 wget -P $MODEL_PATH -N https://storage.googleapis.com/tensorflow-graphics/models/hitnet/default_models/$MODEL_NAME
 
-python -m predict.py \
+python -m predict \
   --data_pattern=$DATA_PATTERN \
   --model_path=$MODEL_PATH/$MODEL_NAME \
   --png_disparity_factor=1024 \

--- a/hitnet/predict_middlebury.sh
+++ b/hitnet/predict_middlebury.sh
@@ -41,7 +41,7 @@ pip3 install -r requirements.txt
 mkdir -p $MODEL_PATH
 wget -P $MODEL_PATH -N https://storage.googleapis.com/tensorflow-graphics/models/hitnet/default_models/$MODEL_NAME
 
-python -m predict.py \
+python -m predict \
   --data_pattern=$DATA_PATTERN \
   --model_path=$MODEL_PATH/$MODEL_NAME \
   --png_disparity_factor=128 \


### PR DESCRIPTION
Generally, if we want to run a python script we use :
-> python hello.py  # to run it as a script file
(or)
-> python -m hello  # to run it as a module

so when we are choosing to run the file as a module .py extension need not be present this will lead to an error.