### PR TITLE
commented unused import module csv ipdb

### DIFF
--- a/persistent_es/hyperopt/meta_opt.py
+++ b/persistent_es/hyperopt/meta_opt.py
@@ -75,8 +75,8 @@ python meta_opt.py \
 """
 import os
 import sys
-import csv
-import ipdb
+# import csv
+# import ipdb
 import time
 import random
 import pickle as pkl


### PR DESCRIPTION
fixing on ```persistent_es/hyperopt/meta_opt.py``` by:
- commented unused import module of ```csv```
- commented unused import module of ```ipdb```