### PR TITLE
"master" --> "main" in WORKSPACE (Bazel)

### DIFF
--- a/automl_zero/WORKSPACE
+++ b/automl_zero/WORKSPACE
@@ -25,15 +25,15 @@ http_archive(
 
 http_archive(
     name = "rules_cc",
-    strip_prefix = "rules_cc-master",
-    urls = ["https://github.com/bazelbuild/rules_cc/archive/master.zip"],
+    strip_prefix = "rules_cc-main",
+    urls = ["https://github.com/bazelbuild/rules_cc/archive/main.zip"],
 )
 
 http_archive(
     name = "rules_proto",
-    strip_prefix = "rules_proto-master",
+    strip_prefix = "rules_proto-main",
     urls = [
-        "https://github.com/bazelbuild/rules_proto/archive/master.zip",
+        "https://github.com/bazelbuild/rules_proto/archive/main.zip",
     ],
 )
 


### PR DESCRIPTION
the current Bazel (even 3.7.2) requires "main" instead of "master" for rules_cc and rules_proto