### PR TITLE
Modified training end condition

### DIFF
--- a/flax_models/t5x/train.py
+++ b/flax_models/t5x/train.py
@@ -632,8 +632,11 @@ def main(argv):
           epoch)
       optimizer = train_lib.unbroadcast(optimizer)
 
+    #Train model until target_step will be reached.
+    target_step = host_step + CFG.num_epochs * steps_per_epoch
+    
     # Epoch loop.
-    while int(host_step // steps_per_epoch) == epoch:
+    while host_step <= target_step:
       batch = next(train_iter)
       batch = jax.tree_map(
           lambda x: x.reshape(


### PR DESCRIPTION
Old code had a bug: due to the ignored rest during the division between `host_step` and `steps_per_epoch`, the training loop could terminate earlier than desired. Example for `epochs = 1`,  `starting_epoch = 78`, `step_per_epoch = 12_689`. Training loop will end at `step = 1_002_431` (`1_002_431 // 12_689 = 79`), but the correct one should be `step = 1_012_589` (`1_012_589 // 12_689 = 79.8005`).
