### PR TITLE
Update script_train_fixed_params.py

### DIFF
--- a/tft/script_train_fixed_params.py
+++ b/tft/script_train_fixed_params.py
@@ -74,7 +74,7 @@ def main(expt_name,
         "AbstractDataFormatter! Type={}".format(type(data_formatter)))
 
   # Tensorflow setup
-  default_keras_session = tf.keras.backend.get_session()
+  default_keras_session = tf.compat.v1.keras.backend.get_session()
 
   if use_gpu:
     tf_config = utils.get_default_tensorflow_config(tf_device="gpu", gpu_id=0)


### PR DESCRIPTION
The name tf.keras.backend.get_session is deprecated. Please use tf.compat.v1.keras.backend.get_session instead.