### PR TITLE
Scann fixed batch search bug.

### DIFF
--- a/scann/scann/hashes/asymmetric_hashing2/searcher.cc
+++ b/scann/scann/hashes/asymmetric_hashing2/searcher.cc
@@ -292,6 +292,7 @@ Status Searcher<T>::FindNeighborsBatchedInternal(
       if (queries_left <= max_low_level_batch_size_) return queries_left;
 
       if (queries_left >= 2 * max_low_level_batch_size_) {
+        if (queries_left < optimal_low_level_batch_size_) return queries_left;
         return optimal_low_level_batch_size_;
       }
 


### PR DESCRIPTION
max_low_level_batch_size_ = 3
queries_left = 6
optimal_low_level_batch_size_ = 7
return optimal_low_level_batch_size_ = 7; This will cause the array to go out of bounds.