### PR TITLE
in simpdom, set gym version to 0.21.0 because later versions are incompatible

### DIFF
--- a/simpdom/requirements.txt
+++ b/simpdom/requirements.txt
@@ -1,3 +1,4 @@
+gym==v0.21.0
 absl-py>=0.5.0
 numpy>=1.13.3
 tensorflow>=2.0


### PR DESCRIPTION
Using the latest version of gym results in the following stack trace. Installing an earlier version (0.21.0) resolves the problem.

From the README:
python -m simpdom.run_node_level_model --run train --vertical auto --source_website aol-kbb --target_website aol_kbb --result_path results --domtree_data_path swde/extracted_xpaths --goldmine_data_path goldmine_data --batch_size 16 --epochs 1 --circle_features partner --semantic_encoder cos_sim --objective classification --versical=auto --use_uniform_embedding=false --add_goldmine=false

Traceback (most recent call last):
  File "/home/dallan/anaconda3/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/dallan/anaconda3/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/dallan/test/google_research/simpdom/run_node_level_model.py", line 36, in <module>
    from simpdom import models
  File "/home/dallan/test/google_research/simpdom/models.py", line 26, in <module>
    from tensor2tensor.models import transformer
  File "/home/dallan/test/google_research/env/lib/python3.8/site-packages/tensor2tensor/models/__init__.py", line 51, in <module>
    from tensor2tensor.models.research import rl
  File "/home/dallan/test/google_research/env/lib/python3.8/site-packages/tensor2tensor/models/research/rl.py", line 27, in <module>
    from tensor2tensor.envs import tic_tac_toe_env
  File "/home/dallan/test/google_research/env/lib/python3.8/site-packages/tensor2tensor/envs/__init__.py", line 23, in <module>
    from tensor2tensor.envs import tic_tac_toe_env
  File "/home/dallan/test/google_research/env/lib/python3.8/site-packages/tensor2tensor/envs/tic_tac_toe_env.py", line 244, in <module>
    register()
  File "/home/dallan/test/google_research/env/lib/python3.8/site-packages/tensor2tensor/envs/tic_tac_toe_env.py", line 239, in register
    unused_tictactoe_id, unused_tictactoe_env = gym_utils.register_gym_env(
  File "/home/dallan/test/google_research/env/lib/python3.8/site-packages/tensor2tensor/rl/gym_utils.py", line 360, in register_gym_env
    return env_name, gym.make(env_name)
  File "/home/dallan/test/google_research/env/lib/python3.8/site-packages/gym/envs/registration.py", line 676, in make
    return registry.make(id, **kwargs)
  File "/home/dallan/test/google_research/env/lib/python3.8/site-packages/gym/envs/registration.py", line 520, in make
    return spec.make(**kwargs)
  File "/home/dallan/test/google_research/env/lib/python3.8/site-packages/gym/envs/registration.py", line 133, in make
    _kwargs = self.kwargs.copy()
AttributeError: 'NoneType' object has no attribute 'copy'