### PR TITLE
in simpdom, correct pred_string output

### DIFF
--- a/simpdom/models.py
+++ b/simpdom/models.py
@@ -804,8 +804,7 @@ def joint_extraction_model_fn(features, labels, mode, params):
     logging.info("pred_ids.shape: %s", pred_ids.shape)
   # Predict for new sentences in target set.
   if mode == tf_estimator.ModeKeys.PREDICT:
-    reverse_vocab_tags = _index_table_from_file(params["tags"], 1)
-    pred_strings = reverse_vocab_tags.lookup(tf.strings.as_string(pred_ids))
+    pred_strings = tf.gather(np.genfromtxt(params["tags"], dtype="O"), pred_ids)
     predictions = {
         "pred_ids": pred_ids,
         "tags": pred_strings,


### PR DESCRIPTION
in joint_extraction_model_fn, pred_strings are obtained by looking up pred_ids in an index table created from the file params["tags"]. But the purpose of the index table is to look up (string) tags and convert them to their corresponding (integer) indexes, and here we want to look up the (integer) indexes and convert them to their corresponding (string) tags. The result is that the preds txt file contains invalid (integer) predicted tag values, which causes the metrics reported in run_node_level_model to all be 0.