### PR TITLE
Adds custom allocator support to DeserializeFromNpyString().

### DIFF
--- a/npy_array/npy_array/npy_array.cc
+++ b/npy_array/npy_array/npy_array.cc
@@ -18,14 +18,14 @@
 #include <cstdint>
 #include <regex>  // NOLINT: ok to use std::regex in third_party code.
 #include <string>
+#include <string_view>
 #include <vector>
 
-#include "glog/logging.h"
 #include "absl/strings/match.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
-#include "absl/strings/string_view.h"
+#include "glog/logging.h"
 
 namespace npy_array::internal {
 
@@ -115,9 +115,7 @@ std::string NpyDataTypeString<uint64_t>() {
   return "u";
 }
 
-std::string NpyEndiannessString() {
-  return IsLittleEndian() ? "<" : ">";
-}
+std::string NpyEndiannessString() { return IsLittleEndian() ? "<" : ">"; }
 
 std::string NpyShapeString(const std::vector<size_t>& shape) {
   if (shape.empty()) {
@@ -126,7 +124,7 @@ std::string NpyShapeString(const std::vector<size_t>& shape) {
   return "(" + absl::StrJoin(shape.begin(), shape.end(), ",") + ",)";
 }
 
-std::string NpyHeaderLengthString(absl::string_view header) {
+std::string NpyHeaderLengthString(std::string_view header) {
   std::string header_length_string(4, '\0');
   const uint32_t header_length = header.length();
   uint32_t* header_length_ptr =
@@ -138,9 +136,9 @@ std::string NpyHeaderLengthString(absl::string_view header) {
   return header_length_string;
 }
 
-NpyHeader ReadHeader(absl::string_view src) {
+NpyHeader ReadHeader(std::string_view src) {
   NpyHeader header;
-  constexpr absl::string_view kMagic("\x93NUMPY");
+  constexpr std::string_view kMagic("\x93NUMPY");
 
   // Check for size - at least magic + 2 bytes of version. We are going to
   // adjust this value as we go through header parsing.
@@ -207,8 +205,7 @@ NpyHeader ReadHeader(absl::string_view src) {
     // outermost).
     std::regex fortran_order_re("('fortran_order': (False|True))");
     std::smatch match;
-    if (!std::regex_search(header_substr, match,
-                           fortran_order_re)) {
+    if (!std::regex_search(header_substr, match, fortran_order_re)) {
       LOG(ERROR) << "DeserializeFromNpyString ReadHeader unable to parse "
                     "header, couldn't find fortran_order.";
       return NpyHeader();
@@ -221,24 +218,24 @@ NpyHeader ReadHeader(absl::string_view src) {
     std::regex descr_re(R"('descr':\s*'(<|>)(\w)(\d+)')");
     std::smatch match;
     if (!std::regex_search(header_substr, match, descr_re)) {
-        LOG(ERROR) << "DeserializeFromNpyString ReadHeader unable to parse "
-                      "header, couldn't find type descr.";
-        return NpyHeader();
-      }
-      const bool little_endian = match[1].str() == "<";
-
-      // We don't support endianness swapping at the moment.
-      if (little_endian != IsLittleEndian()) {
-        LOG(ERROR) << "DeserializeFromNpyString ReadHeader invalid header, we "
-                      "don't support endianness swapping at the moment.";
-        return NpyHeader();
-      }
-
-      header.type_char = match[2].str()[0];
-      if (!absl::SimpleAtoi(match[3].str(), &header.word_size)) {
-        return NpyHeader();
-      }
+      LOG(ERROR) << "DeserializeFromNpyString ReadHeader unable to parse "
+                    "header, couldn't find type descr.";
+      return NpyHeader();
     }
+    const bool little_endian = match[1].str() == "<";
+
+    // We don't support endianness swapping at the moment.
+    if (little_endian != IsLittleEndian()) {
+      LOG(ERROR) << "DeserializeFromNpyString ReadHeader invalid header, we "
+                    "don't support endianness swapping at the moment.";
+      return NpyHeader();
+    }
+
+    header.type_char = match[2].str()[0];
+    if (!absl::SimpleAtoi(match[3].str(), &header.word_size)) {
+      return NpyHeader();
+    }
+  }
 
   {
     // Find the "shape" (array dimensions).
@@ -252,7 +249,7 @@ NpyHeader ReadHeader(absl::string_view src) {
     std::string shape_desc = match[1];
     header.total_element_count = 1;
     bool last_element = false;
-    for (absl::string_view dim_s : absl::StrSplit(shape_desc, ',')) {
+    for (std::string_view dim_s : absl::StrSplit(shape_desc, ',')) {
       if (dim_s == "") {
         // We allow a trailing "," (empty last element), but if it wasn't really
         // last, it's going to be an error next loop iteration.

--- a/npy_array/npy_array/npy_array.cc
+++ b/npy_array/npy_array/npy_array.cc
@@ -21,11 +21,11 @@
 #include <string_view>
 #include <vector>
 
+#include "glog/logging.h"
 #include "absl/strings/match.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
-#include "glog/logging.h"
 
 namespace npy_array::internal {
 

--- a/npy_array/npy_array/npy_array.h
+++ b/npy_array/npy_array/npy_array.h
@@ -24,9 +24,9 @@
 #include <utility>
 #include <vector>
 
+#include "glog/logging.h"
 #include "absl/strings/str_cat.h"
 #include "array/array.h"
-#include "glog/logging.h"
 
 namespace npy_array {
 

--- a/npy_array/npy_array/npy_array.h
+++ b/npy_array/npy_array/npy_array.h
@@ -20,18 +20,20 @@
 #include <cstdint>
 #include <cstdio>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
-#include "glog/logging.h"
 #include "absl/strings/str_cat.h"
-#include "absl/strings/string_view.h"
 #include "array/array.h"
+#include "glog/logging.h"
 
 namespace npy_array {
 
-// This header exposes a single function, `SerializeToNpyString`, whose behavior
-// can be configured with `NpySerializeOptions`.
+// This header exposes two functions:
+// - `SerializeToNpyString`, whose behavior can be configured with
+// `NpySerializeOptions`.
+// - `DeserializeFromNpyString`.
 
 struct NpySerializeOptions {
   // # In Numpy, shapes are indexed outermost to innermost. #
@@ -143,7 +145,7 @@ std::vector<size_t> NpyShapeVector(ShapeType shape) {
 std::string NpyShapeString(const std::vector<size_t>& shape);
 
 // Encodes the length of `header` in NPY format (four bytes, little endian).
-std::string NpyHeaderLengthString(absl::string_view header);
+std::string NpyHeaderLengthString(std::string_view header);
 
 // Returns the "full" NPY file header for the given DataType and ShapeType.
 // The "full header" consists of the magic 6 bytes, version number, and the
@@ -152,11 +154,11 @@ std::string NpyHeaderLengthString(absl::string_view header);
 // This returns a header for version 2.0.
 template <typename DataType, typename ShapeType>
 std::string NpyFullHeaderString(ShapeType shape, bool reverse_axes) {
-  constexpr absl::string_view kMagic("\x93NUMPY");
+  constexpr std::string_view kMagic("\x93NUMPY");
 
   // The explicit count is required since the \x00 in the literal would be
   // interpreted to construct a string of length 1.
-  constexpr absl::string_view kVersion("\x02\x00", /*count=*/2);
+  constexpr std::string_view kVersion("\x02\x00", /*count=*/2);
 
   // The NPY format says that:
   // - If fortran_order = False (the default NPY ordering):
@@ -248,7 +250,7 @@ struct NpyHeader {
   bool valid = false;
 };
 
-NpyHeader ReadHeader(absl::string_view src);
+NpyHeader ReadHeader(std::string_view src);
 
 template <class Shape, size_t... Is>
 Shape ToShapeImpl(const std::vector<size_t>& sizes,
@@ -270,20 +272,21 @@ std::string SerializeToNpyString(nda::array_ref<DataType, ShapeType> src,
   return internal::SerializeToNpyString(src.cref(), options);
 }
 
-template <typename DataType, typename ShapeType>
-nda::array<DataType, ShapeType> DeserializeFromNpyString(
-    absl::string_view src) {
+template <typename DataType, typename ShapeType,
+          typename Alloc = std::allocator<DataType>>
+nda::array<DataType, ShapeType, Alloc> DeserializeFromNpyString(
+    std::string_view src) {
   if (src.empty()) {
     LOG(ERROR) << "DeserializeFromNpyString: unable to deserialize, got an "
                   "empty string.";
-    return nda::array<DataType, ShapeType>();
+    return nda::array<DataType, ShapeType, Alloc>();
   }
 
   internal::NpyHeader header = internal::ReadHeader(src);
   if (!header.valid) {
     LOG(ERROR) << "DeserializeFromNpyString: unable to deserialize, got an "
                   "invalid npy header.";
-    return nda::array<DataType, ShapeType>();
+    return nda::array<DataType, ShapeType, Alloc>();
   }
 
   // After parsing the header, perform expected data verification.
@@ -294,23 +297,23 @@ nda::array<DataType, ShapeType> DeserializeFromNpyString(
                   "string of length "
                << header.data_start_offset + expected_data_size << ", got "
                << src.size() << ".";
-    return nda::array<DataType, ShapeType>();
+    return nda::array<DataType, ShapeType, Alloc>();
   }
   if (internal::NpyDataTypeString<DataType>()[0] != header.type_char ||
       sizeof(DataType) != header.word_size) {
     LOG(ERROR) << "DeserializeFromNpyString: unable to deserialize, npy "
                   "contains data type "
                << header.type_char << header.word_size << ", while requested "
-               << internal::NpyDataTypeString<DataType>()[0]
-               << sizeof(DataType) << ".";
-    return nda::array<DataType, ShapeType>();
+               << internal::NpyDataTypeString<DataType>()[0] << sizeof(DataType)
+               << ".";
+    return nda::array<DataType, ShapeType, Alloc>();
   }
 
   if (ShapeType::rank() != header.shape.size()) {
     LOG(ERROR) << "DeserializeFromNpyString: unable to deserialize, got rank "
                << header.shape.size() << ", while requested "
                << ShapeType::rank() << ".";
-    return nda::array<DataType, ShapeType>();
+    return nda::array<DataType, ShapeType, Alloc>();
   }
 
   // See the rationale for flipping in NpySerializeOptions.
@@ -318,7 +321,7 @@ nda::array<DataType, ShapeType> DeserializeFromNpyString(
     std::reverse(header.shape.begin(), header.shape.end());
   }
 
-  nda::array<DataType, ShapeType> array = nda::array<DataType, ShapeType>(
+  nda::array<DataType, ShapeType, Alloc> array(
       internal::ToShape<ShapeType>(header.shape));
   src.copy(reinterpret_cast<char*>(array.data()), expected_data_size,
            header.data_start_offset);


### PR DESCRIPTION
Also renames absl::string_view to std::string_view since .bazelrc
specifies C++17 as the default.