### PR TITLE
Update dataloader to support 360 scenes

### DIFF
--- a/regnerf/internal/datasets.py
+++ b/regnerf/internal/datasets.py
@@ -1008,6 +1008,9 @@ class LLFF(Dataset):
       poses, bounds = transform_poses_to_hemisphere(poses, bounds)
       self.render_poses = generate_hemispherical_orbit(
           poses, n_frames=config.render_path_frames)
+      self.near = bounds.min()
+      self.far = bounds.max()
+
     else:
       self.render_poses = generate_spiral_path(
           poses, bounds, n_frames=config.render_path_frames)


### PR DESCRIPTION
360 scenes weren't working without this change. After changing the ray-sampling bounds, it seems to work fine 