### PR TITLE
Remove deprecated `min_cluster_size` from `ScannBuilder` in Python

### DIFF
--- a/scann/scann/scann_ops/py/scann_builder.py
+++ b/scann/scann/scann_ops/py/scann_builder.py
@@ -160,7 +160,6 @@ class ScannBuilder(object):
           }}
           noise_shaping_threshold: {anisotropic_quantization_threshold}
           expected_sample_size: {training_sample_size}
-          min_cluster_size: {min_cluster_size}
           max_clustering_iterations: {training_iterations}
         }}
       }} """


### PR DESCRIPTION
`min_cluster_size` has been deprecated in proto. However, the Python code `scann/scann/scann_ops/py/scann_builder.py` still include it in the proto message, which results in a warning `[libprotobuf WARNING external/com_google_protobuf/src/google/protobuf/text_format.cc:339] Warning parsing text-format research_scann.ScannConfig: 38:5: text format contains deprecated field "min_cluster_size"`.
