### PR TITLE
Code Execution via unsafe method used in "snerg/nerf/utils.py"

### DIFF
--- a/snerg/nerf/utils.py
+++ b/snerg/nerf/utils.py
@@ -239,7 +239,7 @@ def update_flags(args):
   """Update the flags in `args` with the contents of the config YAML file."""
   pth = path.join(BASE_DIR, args.config + ".yaml")
   with open_file(pth, "r") as fin:
-    configs = yaml.load(fin, Loader=yaml.FullLoader)
+    configs = yaml.load(fin, Loader=yaml.SafeLoader)
   # Only allow args to be updated if they already exist.
   invalid_args = list(set(configs.keys()) - set(dir(args)))
   if invalid_args:


### PR DESCRIPTION
The method "FullLoader" on line 242 is unsafe. Instead, the "SafeLoader" method should be used.

The function in "utils.py" is called in the file "train.py" which allows the creation of a malicious YAML file that allows command execution when training a network.

Here is a public disclosure of this vulnerability:

https://huntr.dev/bounties/68070752-c942-4ba1-a789-af74ffda0201/

And the details of why the FullLoader method is unsafe

https://github.com/yaml/pyyaml/issues/420