### PR TITLE
fix the link of installing jaxlib_cuda

### DIFF
--- a/regnerf/README.md
+++ b/regnerf/README.md
@@ -52,7 +52,7 @@ You can then install the dependencies:
 
 Finally, install jaxlib with the appropriate CUDA version (tested with jaxlib 0.1.68 and CUDA 11.0):
 
-```pip install --upgrade jaxlib==0.1.68+cuda110 -f https://storage.googleapis.com/jax-releases/jax_releases.html```
+```pip install --upgrade jaxlib==0.1.68+cuda110 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html```
 
 Note: If you run into problems installing jax, please see [the official documentation](https://github.com/google/jax#pip-installation-gpu-cuda) for additional help.
 


### PR DESCRIPTION
original link doesn not have jaxlib with gpu support