### PR TITLE
fix MUSIQ input decoding for grayscale images

### DIFF
--- a/musiq/model/preprocessing.py
+++ b/musiq/model/preprocessing.py
@@ -300,7 +300,7 @@ def decode_image(encoded_image_bytes):
   Returns:
     The decoded image tensor [H, W, 3].
   """
-  return tf.image.decode_jpeg(encoded_image_bytes)
+  return tf.image.decode_jpeg(encoded_image_bytes, channels=3)
 
 
 def get_preprocess_fn(**preprocessing_kwargs):


### PR DESCRIPTION
The `decode_image` function in `musiq/model/prepocessing.py `called `tf.image.decode_jpeg` with the default `channels=0`, which returns the number of image color channels found in the input. This doesn't work for grayscale images, so it was changed to `channels=3` to always return an RGB image.