### PR TITLE
Updates the links to UL2 20B config

### DIFF
--- a/ul2/README.md
+++ b/ul2/README.md
@@ -13,9 +13,9 @@ The following table contains pretrained UL2 checkpoints.
 
 | Model           |    Size     | Step | Config  | Checkpoint  |
 |:---------------:|:-----------:|:----:|:-------:|:-----------:|
-| UL2    | 20B  | 1870000| [T5 configs](https://storage.googleapis.com/scenic-bucket/ul2/ul220b/config.gin)| `gs://scenic-bucket/ul2/ul220b/checkpoint_1870000` |
-| UL2    | 20B  | 2050000| [T5 configs](https://storage.googleapis.com/scenic-bucket/ul2/ul220b/config.gin)| `gs://scenic-bucket/ul2/ul220b/checkpoint_2050000` |
-| UL2    | 20B  | 2650000| [T5 configs](https://storage.googleapis.com/scenic-bucket/ul2/ul220b/config.gin)| `gs://scenic-bucket/ul2/ul220b/checkpoint_2650000` |
+| UL2    | 20B  | 1870000| [T5 configs](https://storage.googleapis.com/scenic-bucket/ul2/ul220b/ul2_20b.gin)| `gs://scenic-bucket/ul2/ul220b/checkpoint_1870000` |
+| UL2    | 20B  | 2050000| [T5 configs](https://storage.googleapis.com/scenic-bucket/ul2/ul220b/ul2_20b.gin)| `gs://scenic-bucket/ul2/ul220b/checkpoint_2050000` |
+| UL2    | 20B  | 2650000| [T5 configs](https://storage.googleapis.com/scenic-bucket/ul2/ul220b/ul2_20b.gin)| `gs://scenic-bucket/ul2/ul220b/checkpoint_2650000` |
 
 
 ## Reference


### PR DESCRIPTION
Previous links are broken as discussed in https://github.com/google-research/google-research/issues/1091