### PR TITLE
Fix minimum supported TF version in release documentation

### DIFF
--- a/scann/docs/releases.md
+++ b/scann/docs/releases.md
@@ -1,7 +1,7 @@
 # ScaNN Release Notes
 
 ### 1.2.10
-Updated to compile against TensorFlow 2.12; **not** backwards-compatible with earlier versions of TensorFlow.
+Updated to compile against TensorFlow 2.13; **not** backwards-compatible with earlier versions of TensorFlow.
 
 ### 1.2.9
 Updated to compile against TensorFlow 2.11; **not** backwards-compatible with earlier versions of TensorFlow.


### PR DESCRIPTION
Update releases.md to denote that TensorFlow 2.13 is minimum supported version.

It seems [requirements.txt](https://github.com/google-research/google-research/blob/03c4c851a28dffe0244c65089e68d6cbf73c730b/scann/requirements.txt) specifies tensorflow~=2.13.0, thus skipping v2.12 altogether.