### PR TITLE
Fix scenic package requirement in DreamFields

### DIFF
--- a/dreamfields/requirements.txt
+++ b/dreamfields/requirements.txt
@@ -12,7 +12,7 @@ mediapy
 ml_collections
 numpy>=1.21.5
 regex
-git+git://github.com/google-research/scenic.git
+git+https://github.com/google-research/scenic.git
 scipy
 tensorflow>=2.7.0
 tqdm


### PR DESCRIPTION
Installing the requirement from the git repository using the SSH syntax keeps giving connection time out error.

Reported issue: [https://github.com/google-research/google-research/issues/1418](https://github.com/google-research/google-research/issues/1418)

`Resolves #1418 `