### PR TITLE
Correct ISPRS color conversion documentation

### DIFF
--- a/factors_of_influence/fids/isprs.py
+++ b/factors_of_influence/fids/isprs.py
@@ -137,7 +137,7 @@ class ISPRS(fids_dataset.FIDSDataset):
     split_dir = self._get_split_dir(split)
 
     if feature_name in ['image', 'image_raw']:
-      # Convert RGB (Potsdam) and IRG (Vaihingen) to RG[(R+B)/2].
+      # Convert RGB (Potsdam) and IRG (Vaihingen) to RG[(R+G)/2].
       img_raw = utils.load_png(f'{split_dir}/top/{curr_id}')
       if feature_name == 'image_raw':
         return img_raw, True


### PR DESCRIPTION
There is a typo in the inline comments for the color conversion performed when pre-processing the ISPRS dataset: the third channel becomes the mean of the red and blue channels; the green channel is not used.

This is important as the green channel is absent in the Vaihingen dataset, which uses the green channel for infra-red data.