### PR TITLE
Fix absl requirement

### DIFF
--- a/instruction_following_eval/requirements.txt
+++ b/instruction_following_eval/requirements.txt
@@ -1,3 +1,3 @@
-absl
+absl-py
 langdetect
 nltk


### PR DESCRIPTION
The `absl` requirement seems to be misspecified since

```shell
~ ❯ pip install absl
ERROR: Could not find a version that satisfies the requirement absl (from versions: none)
ERROR: No matching distribution found for absl
```

I believe [absl-py](https://pypi.org/project/absl-py/) is the correct package