### PR TITLE
Add missing dependency for instruction_following_eval

### DIFF
--- a/instruction_following_eval/requirements.txt
+++ b/instruction_following_eval/requirements.txt
@@ -1,3 +1,4 @@
 absl
 langdetect
 nltk
+immutabledict


### PR DESCRIPTION
I found this extra dependency was needed to run the code on a fresh Python 3.10 env.