### PR TITLE
Fix typo; root directory uses hyphen as delimiter

### DIFF
--- a/vrdu/README.md
+++ b/vrdu/README.md
@@ -64,7 +64,7 @@ sampling different training docs for the few-shot setting.
 
 
 ## Evaluation Tools
-The ```python -m``` command assumes you are in the `google_research/` directory.
+The ```python -m``` command assumes you are in the `google-research/` directory.
 
 Sample invocation of the evaluation binary (on one dataset):
 


### PR DESCRIPTION
Thank you for [VRDU datasets](https://github.com/google-research-datasets/vrdu) and evaluation tools.

I found a typo, so send this pull request.

```
% git clone git@github.com:google-research/google-research.git
% cd google-research
% python -m vrdu.evaluate --help
```