### PR TITLE
Fix transformation matrix in merf `camera_utils.py`

### DIFF
--- a/merf/internal/camera_utils.py
+++ b/merf/internal/camera_utils.py
@@ -229,7 +229,7 @@ def transform_poses_pca(poses):
   # Just make sure it's it in the [-1, 1]^3 cube
   scale_factor = 1.0 / np.max(np.abs(poses_recentered[:, :3, 3]))
   poses_recentered[:, :3, 3] *= scale_factor
-  transform = np.diag(np.array([scale_factor] * 3 + [1])) @ transform
+  transform = np.diag(np.array([1] * 3 + [scale_factor])) @ transform
 
   return poses_recentered, transform
 


### PR DESCRIPTION
This pull request resolves an issue where the transformation matrix was not correctly aligned with the pose data due to improper scaling.

Previously, the transformation matrix was configured to scale the first three columns, while the pose data scaled only the last column. The modifications in this PR ensure that the transformation matrix corresponds appropriately with the transformations of the pose data.