### PR TITLE
fixed ERROR: No matching distribution found for absl

### DIFF
--- a/instruction_following_eval/requirements.txt
+++ b/instruction_following_eval/requirements.txt
@@ -1,4 +1,4 @@
-absl
+absl-py
 langdetect
 nltk
 immutabledict


### PR DESCRIPTION
`absl` -> `absl-py`