### PR TITLE
Replace SVN with partial clone + sparse checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,9 @@ interest:
 
 ```
 SUBDIR=foo
-svn export https://github.com/google-research/google-research/trunk/$SUBDIR
-```
-
-If you'd like to submit a pull request, you'll need to clone the repository;
-we recommend making a shallow clone (without history).
-
-```
-git clone git@github.com:google-research/google-research.git --depth=1
+git clone --no-checkout --filter=blob:none git@github.com:google-research/google-research.git
+git sparse-checkout set $SUBDIR
+git checkout master
 ```
 
 ---


### PR DESCRIPTION
Github's SVN support was killed at the beginning of the year.

This also deletes the shallow clone instruction for PRs, as it seems redundant and I was able to commit using the same setup. I guess the clone could also be made shallow, but it doesn't seem necessary to save even more space; the clone is already below 6 MiB when I try.