### PR TITLE
Update README.md

### DIFF
--- a/fvlm/README.md
+++ b/fvlm/README.md
@@ -7,9 +7,17 @@ The model is also supported on the Cloud Vertex API [here](https://console.cloud
 ## Installation
 We use the Python built-in virtual env to set up the environment. Run the following commands:
 
-```
-svn export https://github.com/google-research/google-research/trunk/fvlm
+Shallow clone the parent `google-research` github repository, and sparse-checkout just the `fvlm` sub-directory. 
+This helps avoid the need to clone the full parent repositiory and just access the fvlm sub-directory
 
+```
+git clone --depth=1 --filter=blob:none https://github.com/google-research/google-research.git
+cd ./google-research && git sparse-checkout set fvlm
+```
+
+Set up the venv path and activate it.
+
+```
 PATH_TO_VENV=/path/to/your/venv
 python3 -m venv ${PATH_TO_VENV}
 source ${PATH_TO_VENV}/bin/activate
@@ -18,6 +26,7 @@ source ${PATH_TO_VENV}/bin/activate
 Install the requirements from the root fvlm directory.
 
 ```
+cd ./fvlm
 pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
GitHub doesn't support SVN checkouts anymore, so I have update the readme for `fvlm` with replacement instructions that I have confirmed are working. We basically need to use a combination of github's shallow copy and sparse checkout functionality.
Also added comments etc to explain the steps.

I would also suggest updating `fvlm`'s linked colab notebook (supported via [vertex-ai](https://console.cloud.google.com/vertex-ai/publishers/google/model-garden/109)) like so, as it is currently not functional without these changes:

<img width="968" alt="Screenshot 2024-11-27 at 1 10 01 PM" src="https://github.com/user-attachments/assets/820f15cd-7c40-489e-a865-1ed0d3e85892">