### PR TITLE
Make LetterFrequencyChecker work for symbols

### DIFF
--- a/instruction_following_eval/instructions.py
+++ b/instruction_following_eval/instructions.py
@@ -1337,8 +1337,6 @@ class LetterFrequencyChecker(Instruction):
     if (
         not letter
         or len(letter) > 1
-        or ord(letter.lower()) < 97
-        or ord(letter.lower()) > 122
     ):
       self._letter = random.choice(list(string.ascii_letters))
     else:


### PR DESCRIPTION
Currently, a symbol is passed. So

```{"key": 1122, "prompt": "make a tweet for playboy's twitter account without using capital letters. Include at least 4 hashtags, starting with '#'", "instruction_id_list": ["change_case:english_lowercase", "keywords:letter_frequency"], "kwargs": [{}, {"let_relation": "at least", "letter": "#", "let_frequency": 4}]}```