### PR TITLE
scann: Use _mm512_setzero_pd and _mm256_setzero_pd for ZeroOneRegister

### DIFF
--- a/scann/scann/utils/intrinsics/avx2.h
+++ b/scann/scann/utils/intrinsics/avx2.h
@@ -166,7 +166,7 @@ class Avx2<T, kNumRegistersInferred> {
     if constexpr (IsSameAny<T, float>()) {
       return _mm256_setzero_ps();
     } else if constexpr (IsSameAny<T, double>()) {
-      return _mm256_setzero_ps();
+      return _mm256_setzero_pd();
     } else {
       return _mm256_setzero_si256();
     }

--- a/scann/scann/utils/intrinsics/avx512.h
+++ b/scann/scann/utils/intrinsics/avx512.h
@@ -150,7 +150,7 @@ class Avx512<T, kNumRegistersInferred> {
     if constexpr (IsSameAny<T, float>()) {
       return _mm512_setzero_ps();
     } else if constexpr (IsSameAny<T, double>()) {
-      return _mm512_setzero_ps();
+      return _mm512_setzero_pd();
     } else {
       return _mm512_setzero_si512();
     }


### PR DESCRIPTION
@sammymax

While I read the ScaNN logic, I found ZeroOneRegister(), which looks like it should use _mm512_setzero_pd and _mm256_setzero_pd.
AVX and SSE4 looks fine but not for AVX2 and AVX512.

Please let me know if I miss something.

https://github.com/google-research/google-research/blob/7be881346b431080e72217df8546e0bed9f5e241/scann/scann/utils/intrinsics/avx1.h#L154
https://github.com/google-research/google-research/blob/7be881346b431080e72217df8546e0bed9f5e241/scann/scann/utils/intrinsics/sse4.h#L153



