### PR TITLE
scann: Make scann to be more gcc friendly

### DIFF
--- a/scann/scann/base/single_machine_base.h
+++ b/scann/scann/base/single_machine_base.h
@@ -62,6 +62,12 @@ void RetrainAndReindexFixup(UntypedSingleMachineSearcherBase* result,
                             const shared_ptr<Dataset>& dataset,
                             bool retraining_requires_dataset = false);
 
+template <typename T>
+StatusOrSearcherUntyped RetrainAndReindexSearcherImpl(
+    UntypedSingleMachineSearcherBase* untyped_searcher,
+    absl::Mutex* searcher_pointer_mutex, ScannConfig config,
+    shared_ptr<ThreadPool> parallelization_pool);
+
 class UntypedSingleMachineSearcherBase {
  public:
   SCANN_DECLARE_IMMOBILE_CLASS(UntypedSingleMachineSearcherBase);

--- a/scann/scann/utils/intrinsics/fallback.h
+++ b/scann/scann/utils/intrinsics/fallback.h
@@ -35,8 +35,8 @@ class Simd;
 template <typename T, size_t kTensorNumElements0, size_t... kTensorNumElements>
 using SimdFor = Simd<T, kTensorNumElements0, kTensorNumElements...>;
 
-struct Zeros {};
-struct Uninitialized {};
+struct FallbackZeros {};
+struct FallbackUninitialized {};
 
 SCANN_INLINE string_view SimdName() { return "<Non-x86 Fallback>"; }
 SCANN_INLINE bool RuntimeSupportsSimd() { return true; }
@@ -73,10 +73,10 @@ class Simd<T, kNumElementsArg> {
   using IntelType = FakeIntelType<T>;
   static_assert(sizeof(IntelType) == kRegisterBytes);
 
-  Simd(Uninitialized) {}
-  Simd() : Simd(Uninitialized()) {}
+  Simd(FallbackUninitialized) {}
+  Simd() : Simd(FallbackUninitialized()) {}
 
-  SCANN_INLINE Simd(Zeros) { Clear(); }
+  SCANN_INLINE Simd(FallbackZeros) { Clear(); }
 
   SCANN_INLINE Simd(IntelType val) {
     static_assert(kNumElements == 1);
@@ -99,7 +99,7 @@ class Simd<T, kNumElementsArg> {
     }
   }
 
-  SCANN_INLINE Simd& operator=(Zeros val) {
+  SCANN_INLINE Simd& operator=(FallbackZeros val) {
     Clear();
     return *this;
   }
@@ -521,12 +521,12 @@ class Simd {
  public:
   using SimdSubArray = Simd<T, kTensorNumRegisters...>;
 
-  Simd(Uninitialized) {}
-  Simd() : Simd(Uninitialized()) {}
+  Simd(FallbackUninitialized) {}
+  Simd() : Simd(FallbackUninitialized()) {}
 
-  SCANN_INLINE Simd(Zeros) {
+  SCANN_INLINE Simd(FallbackZeros) {
     for (size_t j : Seq(kTensorNumRegisters0)) {
-      tensor_[j] = Zeros();
+      tensor_[j] = FallbackZeros();
     }
   }
 
@@ -561,6 +561,9 @@ class Simd {
  private:
   SimdSubArray tensor_[kTensorNumRegisters0];
 };
+
+using Zeros = FallbackZeros;
+using Uninitialized = FallbackUninitialized;
 
 }  // namespace fallback
 


### PR DESCRIPTION
In https://github.com/daangn, we internally maintain a custom ScaNN build with GCC due to internal issues.
We fixed several issues internally and https://github.com/google-research/google-research/pull/2309 was the part of the issue.
Several issues were reported before to this repo (e.g, https://github.com/google-research/google-research/issues/2271), and this patch will resolve part of the issues except for SIMD issues (we had internal fixes, but we will share patches after more verification)

About this patch, 
* This patch fixes several gcc build error issues due to the absence of forward declaration of ``RetrainAndReindexSearcherImpl``
(is neither function nor member function; cannot be declared friend error)
* This patch fixes ambigious of ``Zeros`` and ``Uninitialized``.
* And the good thing of this patch is that it will not harmful to the clang build too.
