### PR TITLE
docs(table_rag): Add missing link to the dataset

### DIFF
--- a/table_rag/README.md
+++ b/table_rag/README.md
@@ -12,7 +12,7 @@ pip install -r requirements.txt
 ```
 
 ## Data
-Download datasets and pre-built databases from [here]().
+You can download the dataset from [this link](https://console.cloud.google.com/storage/browser/tapas_models/wtq/tables).
 
 ```shell
 tar zxvf arcade_qa.tar.gz


### PR DESCRIPTION
This PR addresses the missing dataset link in the TableRAG documentation.

-   Added the hyperlink to the WikiTableQuestions (WTQ) dataset on Google Cloud Storage, which is used in related projects.
-   This makes the project easier to use for researchers and developers.

Closes #2735