### PR TITLE
Fixed gater_resnet 

### DIFF
--- a/gaternet/gater_resnet.py
+++ b/gaternet/gater_resnet.py
@@ -64,7 +64,7 @@ class BasicBlock(nn.Module):
     self.bn2 = nn.BatchNorm2d(out_channels)
 
     self.shortcut = nn.Sequential()
-    if in_channels != out_channels:
+    if in_channels != out_channels or stride != 1:
       self.shortcut.add_module(
           'conv',
           nn.Conv2d(


### PR DESCRIPTION
Fixed the condition of adding a conv2d layer to self.shortcut by checking also if stride is greater than 1 since we might have input and output channel sizes fixed but the spatial dimension of input feature map is reduced.

Instead of checking "in_channels != out_channels" we check"in_channels != out_channels or stride != 1" .