### PR TITLE
rouge-score: Correct docstring punctuation in score_multi

### DIFF
--- a/rouge/rouge_scorer.py
+++ b/rouge/rouge_scorer.py
@@ -89,7 +89,7 @@ class RougeScorer(scoring.BaseScorer):
     """Calculates rouge scores between targets and prediction.
 
     The target with the maximum f-measure is used for the final score for
-    each score type..
+    each score type.
 
     Args:
       targets: list of texts containing the targets


### PR DESCRIPTION
Fix typo in docstring for score_multi method.