### PR TITLE
Fix to delta-bar-delta update of Trimap

### DIFF
--- a/trimap/trimap.py
+++ b/trimap/trimap.py
@@ -364,7 +364,7 @@ def update_embedding_dbd(embedding, grad, vel, gain, lr, iter_num):
       jnp.maximum(gain * _DAMP_GAIN, _MIN_GAIN))
   vel = gamma * vel - lr * gain * grad
   embedding += vel
-  return embedding, gain, vel
+  return embedding, vel, gain
 
 
 @jax.jit


### PR DESCRIPTION
With the fix implemented, for s-curve with default parameters of trimap transform, the mean velocities and gains in the update step are:
<img width="1200" height="500" alt="image" src="https://github.com/user-attachments/assets/53942453-f453-40f6-a19c-710c70997559" />
Notice the linear increase of the gain, which is the expected behaviour of gain in Delta-Bar-Delta update rule.

Without the fix, the same graph looks like:
<img width="1200" height="500" alt="image" src="https://github.com/user-attachments/assets/26e8cbc9-fab5-492d-90f7-234d4a6da14e" />
