### PR TITLE
fix(trimap): correct indentation of input scaling block in transform()

### DIFF
--- a/trimap/trimap.py
+++ b/trimap/trimap.py
@@ -444,10 +444,10 @@ def transform(key,
         pca_solution = True
         if verbose:
           logging.info('applied PCA')
-        else:
-          inputs -= np.min(inputs)
-          inputs /= np.max(inputs)
-          inputs -= np.mean(inputs, axis=0)
+      else:
+        inputs -= np.min(inputs)
+        inputs /= np.max(inputs)
+        inputs -= np.mean(inputs, axis=0)
     key, use_key = random.split(key)
     triplets, weights = generate_triplets(
         key,


### PR DESCRIPTION
## Problem

In `trimap/trimap.py`, the `else` branch for input normalization (lines 447–450) was incorrectly paired with `if verbose` instead of `if dim > _DIM_PCA and apply_pca`.

**Buggy logic:**
```python
if dim > _DIM_PCA and apply_pca:
    ...
    pca_solution = True
    if verbose:
        logging.info('applied PCA')
    else:               # ← paired with `if verbose` — WRONG
        inputs -= np.min(inputs)
        inputs /= np.max(inputs)
        inputs -= np.mean(inputs, axis=0)
```

This causes two incorrect behaviors:
- When `verbose=False` and PCA **was** applied: scaling runs on PCA-reduced data (incorrect)
- When `verbose=True` and PCA **was not** applied: scaling is skipped entirely (incorrect)

## Fix

Move the `else` block out one indent level so it pairs with `if dim > _DIM_PCA and apply_pca`:

```python
if dim > _DIM_PCA and apply_pca:
    ...
    pca_solution = True
    if verbose:
        logging.info('applied PCA')
else:                   # ← now paired with the PCA condition — correct
    inputs -= np.min(inputs)
    inputs /= np.max(inputs)
    inputs -= np.mean(inputs, axis=0)
```

The scaling block now correctly runs only when PCA was **not** applied, regardless of verbosity.

## Impact

The bug silently corrupts embeddings in non-verbose mode when `dim > 100` and `apply_pca=True` (the default). Since `verbose=False` is the default, most users are affected without knowing it.

Closes #3144