### PR TITLE
scann: Add AArch64 run-time feature detection

### DIFF
--- a/scann/scann/oss_wrappers/BUILD.bazel
+++ b/scann/scann/oss_wrappers/BUILD.bazel
@@ -39,6 +39,7 @@ cc_library(
     hdrs = ["scann_cpu_info.h"],
     deps = [
         "@com_google_absl//absl/base",
+        "@com_google_absl//absl/log:check",
     ],
 )
 

--- a/scann/scann/oss_wrappers/scann_cpu_info.cc
+++ b/scann/scann/oss_wrappers/scann_cpu_info.cc
@@ -14,6 +14,9 @@
 
 
 #include "scann/oss_wrappers/scann_cpu_info.h"
+#include "absl/log/check.h"
+#include <cstdint>
+#include <string>
 
 #include "absl/base/call_once.h"
 #if defined(PLATFORM_IS_X86)
@@ -126,7 +129,7 @@ class CPUIDInfo {
     CHECK(cpuid == nullptr) << __func__ << " ran more than once";
     cpuid = new CPUIDInfo;
 
-    uint32 eax, ebx, ecx, edx;
+    uint32_t eax, ebx, ecx, edx;
 
     GETCPUID(eax, ebx, ecx, edx, 0, 0);
     cpuid->vendor_str_.append(reinterpret_cast<char *>(&ebx), 4);
@@ -154,15 +157,15 @@ class CPUIDInfo {
     cpuid->have_ssse3_ = (ecx >> 9) & 0x1;
     cpuid->have_hypervisor_ = (ecx >> 31) & 1;
 
-    const uint64 xcr0_xmm_mask = 0x2;
-    const uint64 xcr0_ymm_mask = 0x4;
-    const uint64 xcr0_maskreg_mask = 0x20;
-    const uint64 xcr0_zmm0_15_mask = 0x40;
-    const uint64 xcr0_zmm16_31_mask = 0x80;
+    const uint64_t xcr0_xmm_mask = 0x2;
+    const uint64_t xcr0_ymm_mask = 0x4;
+    const uint64_t xcr0_maskreg_mask = 0x20;
+    const uint64_t xcr0_zmm0_15_mask = 0x40;
+    const uint64_t xcr0_zmm16_31_mask = 0x80;
 
-    const uint64 xcr0_avx_mask = xcr0_xmm_mask | xcr0_ymm_mask;
-    const uint64 xcr0_avx512_mask = xcr0_avx_mask | xcr0_maskreg_mask |
-                                    xcr0_zmm0_15_mask | xcr0_zmm16_31_mask;
+    const uint64_t xcr0_avx_mask = xcr0_xmm_mask | xcr0_ymm_mask;
+    const uint64_t xcr0_avx512_mask = xcr0_avx_mask | xcr0_maskreg_mask |
+                                      xcr0_zmm0_15_mask | xcr0_zmm16_31_mask;
 
     const bool have_avx =
 
@@ -183,7 +186,7 @@ class CPUIDInfo {
     cpuid->have_f16c_ = have_avx && ((ecx >> 29) & 0x1);
 
     GETCPUID(eax, ebx, ecx, edx, 7, 0);
-    const uint32 kMaxNumSubLeaves = eax;
+    const uint32_t kMaxNumSubLeaves = eax;
 
     cpuid->have_adx_ = (ebx >> 19) & 0x1;
     cpuid->have_avx2_ = have_avx && ((ebx >> 5) & 0x1);
@@ -327,7 +330,7 @@ class CPUIDInfo {
     return false;
   }
 
-  string vendor_str() const { return vendor_str_; }
+  std::string vendor_str() const { return vendor_str_; }
   int family() const { return family_; }
   int model_num() { return model_num_; }
 
@@ -379,7 +382,7 @@ class CPUIDInfo {
   int have_sse4_2_ : 1;
   int have_ssse3_ : 1;
   int have_hypervisor_ : 1;
-  string vendor_str_;
+  std::string vendor_str_;
   int family_;
   int model_num_;
 };
@@ -450,7 +453,7 @@ class CPUIDInfo {
     if (midr_el1_file.is_open()) {
       std::string line;
       if (static_cast<bool>(getline(midr_el1_file, line))) {
-        uint32 midr_el1 = std::stoul(line, nullptr, 16);
+        uint32_t midr_el1 = std::stoul(line, nullptr, 16);
 
         cpuid->implementer_ = (midr_el1 >> 24) & 0xFF;
         cpuid->variant_ = (midr_el1 >> 20) & 0xF;
@@ -555,7 +558,7 @@ int CPUModelNum() {
 int CPUIDNumSMT() {
 #ifdef PLATFORM_IS_X86
 
-  uint32 eax, ebx, ecx, edx;
+  uint32_t eax, ebx, ecx, edx;
 
   GETCPUID(eax, ebx, ecx, edx, 0, 0);
   if (eax >= 11) {

--- a/scann/scann/oss_wrappers/scann_cpu_info.cc
+++ b/scann/scann/oss_wrappers/scann_cpu_info.cc
@@ -23,11 +23,17 @@
 #include <mutex>
 #endif
 #if defined(PLATFORM_IS_ARM64) && !defined(__APPLE__) && !defined(__OpenBSD__)
-#include <sys/auxv.h>
-#ifndef HWCAP_CPUID
-#define HWCAP_CPUID (1 << 11)
-#endif
+#include <asm/hwcap.h>
 #include <fstream>
+#include <sstream>
+#include <sys/auxv.h>
+
+constexpr unsigned long SCANN_HWCAP_ASIMD = 1UL << 1;
+constexpr unsigned long SCANN_HWCAP_CPUID = 1UL << 11;
+constexpr unsigned long SCANN_HWCAP_ASIMDDP = 1UL << 20;
+constexpr unsigned long SCANN_HWCAP_SVE = 1UL << 22;
+constexpr unsigned long SCANN_HWCAP2_SVE2 = 1UL << 1;
+constexpr unsigned long SCANN_HWCAP2_I8MM = 1UL << 13;
 #endif
 
 #ifdef PLATFORM_IS_X86
@@ -408,6 +414,14 @@ class CPUIDInfo {
       : implementer_(0),
         variant_(0),
         cpunum_(0),
+        have_cpuid_(0),
+        // Neon/ASIMD is mandatory from Armv8.0-A, but we still check HWCAP
+        // explicitly below.
+        have_neon_(1),
+        have_dotprod_(0),
+        have_i8mm_(0),
+        have_sve_(0),
+        have_sve2_(0),
         is_arm_neoverse_v1_(0),
         is_arm_neoverse_n1_(0) {}
 
@@ -416,12 +430,39 @@ class CPUIDInfo {
 
     cpuid = new CPUIDInfo;
 
-    if (!(getauxval(AT_HWCAP) & HWCAP_CPUID)) {
+    const unsigned long hwcap = getauxval(AT_HWCAP);
+    const unsigned long hwcap2 = getauxval(AT_HWCAP2);
+
+    cpuid->have_cpuid_ = (hwcap & SCANN_HWCAP_CPUID) != 0;
+    cpuid->have_neon_ = (hwcap & SCANN_HWCAP_ASIMD) != 0;
+    cpuid->have_dotprod_ = (hwcap & SCANN_HWCAP_ASIMDDP) != 0;
+    cpuid->have_sve_ = (hwcap & SCANN_HWCAP_SVE) != 0;
+    cpuid->have_i8mm_ = (hwcap2 & SCANN_HWCAP2_I8MM) != 0;
+    cpuid->have_sve2_ = (hwcap2 & SCANN_HWCAP2_SVE2) != 0;
+
+    // Dependency: I8MM requires the DotProd extension.
+    if (!cpuid->have_dotprod_) {
+      cpuid->have_i8mm_ = 0;
+    }
+
+    // Dependency: SVE requires both DotProd and I8MM.
+    if (!(cpuid->have_dotprod_ && cpuid->have_i8mm_)) {
+      cpuid->have_sve_ = 0;
+    }
+
+    // Dependency: SVE2 requires SVE.
+    if (!cpuid->have_sve_) {
+      cpuid->have_sve2_ = 0;
+    }
+
+    // Reading MIDR_EL1 requires the kernel to expose CPUID via AT_HWCAP.
+    // Bail out if the capability bit is absent (e.g., older kernels).
+    if (!cpuid->have_cpuid_) {
       return;
     }
 
     int present_cpu = -1;
-#ifndef PLATFORM_WINDOWS
+#if defined(__linux__)
     std::ifstream CPUspresent;
     CPUspresent.open("/sys/devices/system/cpu/present", std::ios::in);
     if (CPUspresent.is_open()) {
@@ -445,7 +486,7 @@ class CPUIDInfo {
       return;
     }
 
-#ifndef PLATFORM_WINDOWS
+#if defined(__linux__)
     std::stringstream str;
     str << "/sys/devices/system/cpu/cpu" << present_cpu
         << "/regs/identification/midr_el1";
@@ -475,6 +516,24 @@ class CPUIDInfo {
 #endif
   }
 
+  static bool TestFeature(CPUFeature feature) {
+    InitCPUIDInfo();
+    switch (feature) {
+      case ARM_NEON:
+        return cpuid && cpuid->have_neon_;
+      case ARM_DOTPROD:
+        return cpuid && cpuid->have_dotprod_;
+      case ARM_I8MM:
+        return cpuid && cpuid->have_i8mm_;
+      case ARM_SVE:
+        return cpuid && cpuid->have_sve_;
+      case ARM_SVE2:
+        return cpuid && cpuid->have_sve2_;
+      default:
+        return false;
+    }
+  }
+
   int implementer() const { return implementer_; }
   int cpunum() const { return cpunum_; }
 
@@ -492,8 +551,15 @@ class CPUIDInfo {
   int implementer_;
   int variant_;
   int cpunum_;
-  int is_arm_neoverse_v1_;
-  int is_arm_neoverse_n1_;
+  int have_cpuid_ : 1;
+  int have_neon_ : 1;
+  int have_crc32_ : 1;
+  int have_dotprod_ : 1;
+  int have_i8mm_ : 1;
+  int have_sve_ : 1;
+  int have_sve2_ : 1;
+  int is_arm_neoverse_v1_ : 1;
+  int is_arm_neoverse_n1_ : 1;
 };
 
 absl::once_flag cpuid_once_flag;
@@ -507,7 +573,8 @@ void InitCPUIDInfo() {
 }  // namespace
 
 bool TestCPUFeature(CPUFeature feature) {
-#ifdef PLATFORM_IS_X86
+#if defined(PLATFORM_IS_X86) || (defined(PLATFORM_IS_ARM64) &&                 \
+                                 !defined(__APPLE__) && !defined(__OpenBSD__))
   return CPUIDInfo::TestFeature(feature);
 #else
   return false;

--- a/scann/scann/oss_wrappers/scann_cpu_info.h
+++ b/scann/scann/oss_wrappers/scann_cpu_info.h
@@ -19,6 +19,14 @@
 
 #include <string>
 
+#if !defined(PLATFORM_IS_X86) && defined(__x86_64__)
+#define PLATFORM_IS_X86 1
+#endif
+
+#if !defined(PLATFORM_IS_ARM64) && defined(__aarch64__)
+#define PLATFORM_IS_ARM64 1
+#endif
+
 #if defined(_MSC_VER)
 
 #include <intrin.h>

--- a/scann/scann/oss_wrappers/scann_cpu_info.h
+++ b/scann/scann/oss_wrappers/scann_cpu_info.h
@@ -104,6 +104,13 @@ enum CPUFeature {
   AMX_FP16 = 45,
   AVX_NE_CONVERT = 46,
   AVX_VNNI_INT8 = 47,
+
+  // Arm/AArch64 features.
+  ARM_NEON = 100,
+  ARM_DOTPROD = 101,
+  ARM_I8MM = 102,
+  ARM_SVE = 103,
+  ARM_SVE2 = 104,
 };
 
 enum Aarch64CPU {

--- a/scann/scann/utils/intrinsics/flags.cc
+++ b/scann/scann/utils/intrinsics/flags.cc
@@ -42,6 +42,16 @@ ABSL_RETIRED_FLAG(bool, ignore_avx, false, "Ignore AVX1.");
 
 ABSL_RETIRED_FLAG(bool, ignore_sse4, false, "Ignore SSE4");
 
+ABSL_FLAG(bool, ignore_neon, false, "Ignore Neon/ASIMD.");
+
+ABSL_FLAG(bool, ignore_neon_dotprod, false, "Ignore Neon DotProd.");
+
+ABSL_FLAG(bool, ignore_neon_i8mm, false, "Ignore Neon I8MM.");
+
+ABSL_FLAG(bool, ignore_sve, false, "Ignore SVE.");
+
+ABSL_FLAG(bool, ignore_sve2, false, "Ignore SVE2.");
+
 namespace research_scann {
 namespace flags_internal {
 
@@ -58,6 +68,20 @@ bool should_use_amx = should_use_avx512_vnni &&
                       port::TestCPUFeature(port::AMX_INT8) &&
                       port::TestCPUFeature(port::AMX_BF16) &&
                       port::TestCPUFeature(port::AMX_TILE);
+
+bool should_use_neon =
+    port::TestCPUFeature(port::ARM_NEON) && !absl::GetFlag(FLAGS_ignore_neon);
+bool should_use_neon_dotprod = should_use_neon &&
+                               port::TestCPUFeature(port::ARM_DOTPROD) &&
+                               !absl::GetFlag(FLAGS_ignore_neon_dotprod);
+bool should_use_neon_i8mm = should_use_neon_dotprod &&
+                            port::TestCPUFeature(port::ARM_I8MM) &&
+                            !absl::GetFlag(FLAGS_ignore_neon_i8mm);
+bool should_use_sve = should_use_neon_i8mm &&
+                      port::TestCPUFeature(port::ARM_SVE) &&
+                      !absl::GetFlag(FLAGS_ignore_sve);
+bool should_use_sve2 = should_use_sve && port::TestCPUFeature(port::ARM_SVE2) &&
+                       !absl::GetFlag(FLAGS_ignore_sve2);
 
 bool TryEnableAmx() {
 #ifdef __x86_64__

--- a/scann/scann/utils/intrinsics/flags.h
+++ b/scann/scann/utils/intrinsics/flags.h
@@ -24,6 +24,16 @@ ABSL_DECLARE_FLAG(bool, ignore_avx512);
 
 ABSL_DECLARE_FLAG(bool, ignore_avx2);
 
+ABSL_DECLARE_FLAG(bool, ignore_neon);
+
+ABSL_DECLARE_FLAG(bool, ignore_neon_dotprod);
+
+ABSL_DECLARE_FLAG(bool, ignore_neon_i8mm);
+
+ABSL_DECLARE_FLAG(bool, ignore_sve);
+
+ABSL_DECLARE_FLAG(bool, ignore_sve2);
+
 namespace research_scann {
 namespace flags_internal {
 
@@ -33,6 +43,11 @@ extern bool should_use_avx512_vnni;
 extern bool should_use_amx;
 bool TryEnableAmx();
 
+extern bool should_use_neon;
+extern bool should_use_neon_dotprod;
+extern bool should_use_neon_i8mm;
+extern bool should_use_sve;
+extern bool should_use_sve2;
 }  // namespace flags_internal
 
 #ifdef __x86_64__
@@ -83,6 +98,24 @@ inline bool RuntimeSupportsAmx() { return false; }
 inline bool RuntimeSupportsSse4() { return false; }
 inline bool RuntimeSupportsAvx1() { return false; }
 
+#endif
+
+#ifdef __aarch64__
+inline bool RuntimeSupportsNeon() { return flags_internal::should_use_neon; }
+inline bool RuntimeSupportsNeonDotprod() {
+  return flags_internal::should_use_neon_dotprod;
+}
+inline bool RuntimeSupportsNeonI8MM() {
+  return flags_internal::should_use_neon_i8mm;
+}
+inline bool RuntimeSupportsSVE() { return flags_internal::should_use_sve; }
+inline bool RuntimeSupportsSVE2() { return flags_internal::should_use_sve2; }
+#else
+inline bool RuntimeSupportsNeon() { return false; }
+inline bool RuntimeSupportsNeonDotprod() { return false; }
+inline bool RuntimeSupportsNeonI8MM() { return false; }
+inline bool RuntimeSupportsSVE() { return false; }
+inline bool RuntimeSupportsSVE2() { return false; }
 #endif
 
 enum PlatformGeneration {


### PR DESCRIPTION
This PR adds AArch64 run-time feature detection for ScaNN using `getauxval`/HWCAP, and wires the detected CPU features into the existing `RuntimeSupports*()` APIs. This prepares ScaNN for runtime dispatch of AArch64 optimized implementations, including upcoming Neon/SVE code paths.

The PR also adds fallback definitions for TensorFlow’s `PLATFORM_IS_X86` / `PLATFORM_IS_ARM64` macros when the TensorFlow platform header is absent in standalone/pip builds, since the run-time feature detection path relies on these platform macros.

Author: @gerdamore-arm, [gerdazsejke.more@arm.com](mailto:gerdazsejke.more@arm.com)
CC: @jwright-arm, [jonathan.wright@arm.com](mailto:jonathan.wright@arm.com)