### PR TITLE
scann: Add Arm Neon implementation of ComputePushMask

### DIFF
--- a/scann/scann/hashes/internal/BUILD.bazel
+++ b/scann/scann/hashes/internal/BUILD.bazel
@@ -193,7 +193,10 @@ batch_size_sharder(
 cc_library(
     name = "lut16_highway",
     srcs = [":lut16_highway_batches"],
-    hdrs = ["lut16_highway.h"],
+    hdrs = [
+        "lut16_highway.h",
+        "lut16_neon.h",
+    ],
     # We build this library at -O3 even for fastbuild and dbg
     # builds.  With inlining, functions in this library generate
     # enormous stack frames in debug mode, causing stack overflows
@@ -201,7 +204,10 @@ cc_library(
     copts = [
         "-O3",
     ],
-    textual_hdrs = ["lut16_highway.inc"],
+    textual_hdrs = [
+        "lut16_highway.inc",
+        "lut16_neon.inc",
+    ],
     deps = [
         ":lut16_args",
         "//scann/oss_wrappers:scann_bits",

--- a/scann/scann/hashes/internal/lut16_highway.inc
+++ b/scann/scann/hashes/internal/lut16_highway.inc
@@ -19,6 +19,10 @@
 #include "scann/utils/common.h"
 #include "scann/utils/intrinsics/attributes.h"
 
+#if defined(__aarch64__) && !defined(SCANN_FORCE_HIGHWAY_LUT16)
+#include "scann/hashes/internal/lut16_neon.h"
+#endif
+
 HWY_BEFORE_NAMESPACE();
 
 namespace research_scann {
@@ -73,6 +77,10 @@ SCANN_HIGHWAY_INLINE void ConvertToFloatMultiplyAndStore(const int32_t* dist32,
 
 SCANN_HIGHWAY_INLINE uint32_t
 ComputePushMask(const int16_t* HWY_RESTRICT dist16, const int16_t threshold) {
+#if defined(__aarch64__) && !defined(SCANN_FORCE_HIGHWAY_LUT16)
+  return research_scann::asymmetric_hashing_internal::neon::ComputePushMask(
+      dist16, threshold);
+#else
   const hn::ScalableTag<int16_t> d16;
   using V16 = decltype(hn::Zero(d16));
   const size_t N = hn::Lanes(d16);
@@ -93,6 +101,7 @@ ComputePushMask(const int16_t* HWY_RESTRICT dist16, const int16_t threshold) {
     ret |= (uint32_t)mask_bits[i] << (i * 8);
   }
   return ret;
+#endif
 }
 
 SCANN_HIGHWAY_INLINE void ExpandConvertToFloatAndStore(

--- a/scann/scann/hashes/internal/lut16_neon.h
+++ b/scann/scann/hashes/internal/lut16_neon.h
@@ -1,0 +1,36 @@
+// Copyright 2026 The Google Research Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SCANN_HASHES_INTERNAL_LUT16_NEON_H_
+#define SCANN_HASHES_INTERNAL_LUT16_NEON_H_
+
+#include <cstdint>
+
+#include "scann/utils/intrinsics/attributes.h"
+
+#if defined(__aarch64__)
+namespace research_scann {
+namespace asymmetric_hashing_internal {
+namespace neon {
+
+SCANN_INLINE uint32_t ComputePushMask(const int16_t* dist16, int16_t threshold);
+
+}  // namespace neon
+}  // namespace asymmetric_hashing_internal
+}  // namespace research_scann
+
+#include "scann/hashes/internal/lut16_neon.inc"
+#endif  // defined(__aarch64__)
+
+#endif  // SCANN_HASHES_INTERNAL_LUT16_NEON_H_

--- a/scann/scann/hashes/internal/lut16_neon.inc
+++ b/scann/scann/hashes/internal/lut16_neon.inc
@@ -1,0 +1,44 @@
+#if defined(__aarch64__)
+#include <arm_neon.h>
+
+namespace research_scann {
+namespace asymmetric_hashing_internal {
+namespace neon {
+
+SCANN_INLINE uint32_t ComputePushMask(const int16_t* dist16,
+                                      int16_t threshold) {
+  const uint8x16_t bit_weights =
+      vreinterpretq_u8_u64(vdupq_n_u64(0x8040201008040201ULL));
+
+  const int16x8_t th = vdupq_n_s16(threshold);
+  const int16x8_t d0 = vld1q_s16(dist16 + 0);
+  const int16x8_t d1 = vld1q_s16(dist16 + 8);
+  const int16x8_t d2 = vld1q_s16(dist16 + 16);
+  const int16x8_t d3 = vld1q_s16(dist16 + 24);
+
+  uint16x8_t cmp0 = vcgtq_s16(th, d0);
+  uint16x8_t cmp1 = vcgtq_s16(th, d1);
+  uint16x8_t cmp2 = vcgtq_s16(th, d2);
+  uint16x8_t cmp3 = vcgtq_s16(th, d3);
+
+  const uint8x16_t cmp01 =
+      vuzp1q_u8(vreinterpretq_u8_u16(cmp0), vreinterpretq_u8_u16(cmp1));
+  const uint8x16_t cmp23 =
+      vuzp1q_u8(vreinterpretq_u8_u16(cmp2), vreinterpretq_u8_u16(cmp3));
+
+  const uint8x16_t d01_weights = vandq_u8(cmp01, bit_weights);
+  const uint8x16_t d23_weights = vandq_u8(cmp23, bit_weights);
+
+  const uint8x16_t d0123_weights = vpaddq_u8(d01_weights, d23_weights);
+
+  uint8x8_t res = vget_low_u8(vpaddq_u8(d0123_weights, d0123_weights));
+  res = vpadd_u8(res, res);
+
+  return vget_lane_u32(vreinterpret_u32_u8(res), 0);
+}
+
+}  // namespace neon
+}  // namespace asymmetric_hashing_internal
+}  // namespace research_scann
+
+#endif  // defined(__aarch64__)


### PR DESCRIPTION
Add Neon implementation of ComputePushMask, which is faster than the Highway implementation, as shown below.

```
Platform          Speedup
Neoverse V2       1.49x
Neoverse N3       1.59x
```

The implementation was tested against the Highway implementation using custom unit tests, since there do not appear to be existing unit tests for these paths in the repo.

Author: @gerdamore-arm, [gerdazsejke.more@arm.com](mailto:gerdazsejke.more@arm.com)
CC: @jwright-arm, [jonathan.wright@arm.com](mailto:jonathan.wright@arm.com)