### PR TITLE
Fix TriMap transform preprocessing branch

### DIFF
--- a/trimap/trimap.py
+++ b/trimap/trimap.py
@@ -444,10 +444,10 @@ def transform(key,
         pca_solution = True
         if verbose:
           logging.info('applied PCA')
-        else:
-          inputs -= np.min(inputs)
-          inputs /= np.max(inputs)
-          inputs -= np.mean(inputs, axis=0)
+      else:
+        inputs -= np.min(inputs)
+        inputs /= np.max(inputs)
+        inputs -= np.mean(inputs, axis=0)
     key, use_key = random.split(key)
     triplets, weights = generate_triplets(
         key,

--- a/trimap/trimap_test.py
+++ b/trimap/trimap_test.py
@@ -15,6 +15,8 @@
 
 """Tests for TriMap."""
 
+from unittest import mock
+
 from absl.testing import absltest
 import jax
 import jax.numpy as jnp
@@ -100,6 +102,35 @@ class TestTrimap(absltest.TestCase):
     embedding = trimap.transform(key, inputs, n_dims=4)
     npt.assert_equal(embedding.shape[0], inputs.shape[0])
     npt.assert_equal(embedding.shape[1], 4)
+
+  def test_transform_normalizes_without_pca(self):
+    key = random.PRNGKey(42)
+    inputs = np.array(
+        [[2.0, 4.0], [4.0, 8.0], [6.0, 12.0], [8.0, 16.0]],
+        dtype=np.float32)
+    expected_inputs = inputs.copy()
+    expected_inputs -= np.min(expected_inputs)
+    expected_inputs /= np.max(expected_inputs)
+    expected_inputs -= np.mean(expected_inputs, axis=0)
+
+    captured_inputs = []
+
+    def fake_generate_triplets(key, inputs, *args, **kwargs):
+      del key, args, kwargs
+      captured_inputs.append(inputs.copy())
+      return np.array([[0, 1, 2]], dtype=np.int32), np.array([1.0],
+                                                            dtype=np.float32)
+
+    with mock.patch.object(trimap, 'generate_triplets', fake_generate_triplets):
+      embedding = trimap.transform(
+          key,
+          inputs,
+          n_inliers=2,
+          init_embedding=np.zeros((inputs.shape[0], 2), dtype=np.float32),
+          n_iters=0)
+
+    npt.assert_equal(embedding.shape, (inputs.shape[0], 2))
+    npt.assert_allclose(captured_inputs[0], expected_inputs)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #3144.

## Summary
- Move non-PCA input normalization out from under the verbose-only else branch.
- Add a focused regression test that verifies transform normalizes low-dimensional inputs before triplet generation.

## Testing
- .venv/bin/python -m unittest trimap.trimap_test.TestTrimap.test_transform_normalizes_without_pca
- .venv/bin/python -m py_compile trimap/trimap.py trimap/trimap_test.py
- .venv/bin/python -m trimap.trimap_test (fails only in existing TestTrimap.test_sliced_distances exact float equality: max abs diff 9.536743e-07)