### PR TITLE
Make instruction following evaluation deterministic

### DIFF
--- a/instruction_following_eval/instructions.py
+++ b/instruction_following_eval/instructions.py
@@ -27,6 +27,9 @@ import langdetect
 from instruction_following_eval import instructions_util
 
 
+langdetect.DetectorFactory.seed = 0
+
+
 _InstructionArgsDtype = Optional[Dict[str, Union[int, str, Sequence[str]]]]
 
 _LANGUAGES = instructions_util.LANGUAGE_CODES
@@ -1334,20 +1337,19 @@ class LetterFrequencyChecker(Instruction):
     Returns:
       A string representing the instruction description.
     """
-    if (
-        not letter
-        or len(letter) > 1
-        or ord(letter.lower()) < 97
-        or ord(letter.lower()) > 122
-    ):
+    if letter is None:
       self._letter = random.choice(list(string.ascii_letters))
     else:
       self._letter = letter.strip()
+      if len(self._letter) != 1:
+        raise ValueError('letter must be a single non-whitespace character.')
     self._letter = self._letter.lower()
 
     self._frequency = let_frequency
-    if self._frequency is None or self._frequency < 0:
+    if self._frequency is None:
       self._frequency = random.randint(1, _LETTER_FREQUENCY)
+    elif self._frequency < 0:
+      raise ValueError('let_frequency must be non-negative.')
 
     if let_relation is None:
       self._comparison_relation = random.choice(_COMPARISON_RELATION)

--- a/instruction_following_eval/instructions_test.py
+++ b/instruction_following_eval/instructions_test.py
@@ -42,6 +42,9 @@ class InstructionsTest(parameterized.TestCase):
     instruction.build_description(language=language)
     self.assertTrue(instruction.check_following(response))
 
+  def test_language_detection_seed_is_fixed(self):
+    self.assertEqual(instructions.langdetect.DetectorFactory.seed, 0)
+
   @parameterized.named_parameters(
       [
           {
@@ -1127,6 +1130,33 @@ I love it too much. I'll just have to make sure to eat it in moderation.
     with self.subTest(f'test {self.TEST_LETTER_FREQUENCY_MESSAGE_2}'):
       self.assertFalse(
           instruction.check_following(self.TEST_LETTER_FREQUENCY_MESSAGE_2)
+      )
+
+  def test_letter_frequency_checker_accepts_punctuation(self):
+    instruction = instructions.LetterFrequencyChecker(
+        'keywords:letter_frequency'
+    )
+    description = instruction.build_description(
+        letter='#',
+        let_frequency=4,
+        let_relation=instructions._COMPARISON_RELATION[1],
+    )
+
+    self.assertIn('letter #', description)
+    self.assertTrue(instruction.check_following('#one #two #three #four'))
+    self.assertFalse(instruction.check_following('#one #two #three'))
+
+  def test_letter_frequency_checker_rejects_invalid_explicit_args(self):
+    instruction = instructions.LetterFrequencyChecker(
+        'keywords:letter_frequency'
+    )
+    with self.assertRaisesRegex(ValueError, 'single non-whitespace character'):
+      instruction.build_description(
+          letter='ab', let_frequency=1, let_relation='at least'
+      )
+    with self.assertRaisesRegex(ValueError, 'let_frequency must be non-negative'):
+      instruction.build_description(
+          letter='a', let_frequency=-1, let_relation='at least'
       )
 
   TEST_ENGLISH_CAPITAL_1 = """


### PR DESCRIPTION
Fixes #3427.

Preserves explicitly supplied single-character punctuation in `LetterFrequencyChecker` instead of replacing it with a random ASCII letter, and rejects malformed explicit values instead of randomizing them. Also fixes the `langdetect` seed so language checks are repeatable.

Validation:
- all 44 `instructions_test` tests pass
- prompt 1122 punctuation regression
- Python syntax compilation
- `git diff --check`
